### PR TITLE
Feature improve retrieval and chunking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,5 +154,6 @@ Thumbs.db
 data/
 idea_and_info/
 
-# Todo
+# Todo and claude agents
 TODO.md
+/.claude

--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ Thumbs.db
 # Project specific
 data/
 idea_and_info/
+
+# Todo
+TODO.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Cross-encoder reranking** — search results are re-scored by a cross-encoder (`cross-encoder/ms-marco-MiniLM-L-2-v2`) for significantly improved precision; the bi-encoder fetches 3× candidates and the cross-encoder selects the best matches
 - **Parallel document ingestion** — files are parsed in parallel via `ProcessPoolExecutor` (up to 4 workers) when indexing ≥ 4 documents; embedding and storage remain on the main process for thread-safety
+- **Balanced hardware auto-selection for embeddings** — DocFinder now chooses the best available runtime more robustly (e.g. NVIDIA systems without ONNX CUDA provider fall back to PyTorch CUDA instead of CPU)
+- **Balanced adaptive indexing workers** — parallel parser worker count now adapts automatically to CPU/RAM
+- **Runtime diagnostics in settings/system info** — backend/device/GPU/indexing mode are exposed for easier troubleshooting
 - **Hybrid RAG context strategy** — small documents (≤ 20 chunks) are loaded entirely into the RAG context, while large documents use a sliding window around the matched chunk
 - **Table extraction from PDFs** — PyMuPDF `find_tables()` extracts structured tables and converts them to Markdown for better embedding quality
 - New `Reranker` class with lazy model loading (`index/reranker.py`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Cross-encoder reranking** — search results are re-scored by a cross-encoder (`cross-encoder/ms-marco-MiniLM-L-2-v2`) for significantly improved precision; the bi-encoder fetches 3× candidates and the cross-encoder selects the best matches
+- **Parallel document ingestion** — files are parsed in parallel via `ProcessPoolExecutor` (up to 4 workers) when indexing ≥ 4 documents; embedding and storage remain on the main process for thread-safety
+- **Hybrid RAG context strategy** — small documents (≤ 20 chunks) are loaded entirely into the RAG context, while large documents use a sliding window around the matched chunk
+- **Table extraction from PDFs** — PyMuPDF `find_tables()` extracts structured tables and converts them to Markdown for better embedding quality
+- New `Reranker` class with lazy model loading (`index/reranker.py`)
+- New storage methods `get_document_chunk_count()` and `get_all_chunks()` for hybrid context
+- Reranker model pre-loaded at startup alongside the embedding model
+
+### Changed
+- Spotlight panel (`spotlight.html`) redesigned to match the main app's visual style (indigo accent, smaller search bar, rounded result items)
+
+
 ## [2.0.0] - 2026-03-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-04-25
+
 ### Added
 - **Cross-encoder reranking** — search results are re-scored by a cross-encoder (`cross-encoder/ms-marco-MiniLM-L-2-v2`) for significantly improved precision; the bi-encoder fetches 3× candidates and the cross-encoder selects the best matches
 - **Parallel document ingestion** — files are parsed in parallel via `ProcessPoolExecutor` (up to 4 workers) when indexing ≥ 4 documents; embedding and storage remain on the main process for thread-safety
@@ -18,9 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `Reranker` class with lazy model loading (`index/reranker.py`)
 - New storage methods `get_document_chunk_count()` and `get_all_chunks()` for hybrid context
 - Reranker model pre-loaded at startup alongside the embedding model
+- **Search folder filters** — Search tab now includes selectable indexed directory filters (All/None + checkboxes) and applies filtering at query time without re-indexing
 
 ### Changed
 - Spotlight panel (`spotlight.html`) redesigned to match the main app's visual style (indigo accent, smaller search bar, rounded result items)
+- Spotlight quick-search input now has rounded corners and less aggressive filtering (min 2 chars, softer score threshold + fallback rendering)
+- ONNX fallback now preserves the best available torch device (`cuda`/`mps`) instead of forcing CPU
 
 
 ## [2.0.0] - 2026-03-12
@@ -233,7 +238,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed linting issues for consistent code style
 - Updated ruff configuration to use non-deprecated settings
 
-[Unreleased]: https://github.com/filippostanghellini/DocFinder/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/filippostanghellini/DocFinder/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/filippostanghellini/DocFinder/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/filippostanghellini/DocFinder/compare/v1.2.0...v2.0.0
 [1.2.0]: https://github.com/filippostanghellini/DocFinder/compare/v1.1.2...v1.2.0
 [1.1.2]: https://github.com/filippostanghellini/DocFinder/compare/v1.1.1...v1.1.2

--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ make run     # desktop GUI
 make run-web # web interface at http://127.0.0.1:8000
 ```
 
+### Runtime acceleration (auto)
+
+DocFinder automatically selects the best available runtime on your machine:
+
+- NVIDIA: ONNX CUDA provider when available, otherwise PyTorch CUDA
+- AMD: ONNX ROCm provider when available, otherwise PyTorch fallback
+- Apple Silicon: optimized ONNX path
+- CPU-only hosts: ONNX or PyTorch CPU fallback
+
+Indexing uses a balanced parallel parser strategy by default, selected automatically based on your
+machine resources.
+
 ## Contributing
 
 Contributions are welcome, feel free to open an issue or submit a pull request.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docfinder"
-version = "2.0.0"
+version = "2.1.0"
 license = "AGPL-3.0-or-later"
 description = "Local-first semantic search CLI for your documents (PDF, DOCX, Markdown, TXT)."
 authors = [

--- a/src/docfinder/embedding/encoder.py
+++ b/src/docfinder/embedding/encoder.py
@@ -84,47 +84,92 @@ def detect_optimal_backend() -> tuple[Literal["torch", "onnx"], str | None]:
         - Intel Mac: Use ONNX with standard model
         - CPU only: Use ONNX with standard model
     """
+    backend, onnx_model_file, _device = detect_optimal_backend_config()
+    return (backend, onnx_model_file)
+
+
+def detect_optimal_backend_config() -> tuple[
+    Literal["torch", "onnx"],
+    str | None,
+    str | None,
+]:
+    """Auto-detect backend and device with balanced best-available policy.
+
+    Returns:
+        (backend_name, onnx_model_file, device)
+    """
     try:
         has_gpu, gpu_type = _check_gpu_availability()
         onnx_providers = _check_onnx_providers()
 
-        # Apple Silicon - use quantized ONNX + CoreML
+        # Apple Silicon - prefer quantized ONNX model
         if sys.platform == "darwin" and (
             platform.processor() == "arm" or platform.machine() == "arm64"
         ):
-            logger.info("Detected Apple Silicon - using ONNX with ARM64 quantized model + CoreML")
-            return ("onnx", "onnx/model_qint8_arm64.onnx")
+            logger.info("Detected Apple Silicon - using ONNX with ARM64 quantized model")
+            return ("onnx", "onnx/model_qint8_arm64.onnx", None)
 
-        # NVIDIA GPU - use ONNX with CUDA if provider available
-        if gpu_type == "cuda" and "CUDAExecutionProvider" in onnx_providers:
-            logger.info("Detected NVIDIA GPU with CUDA - using ONNX with CUDA acceleration")
-            return ("onnx", None)
+        # NVIDIA GPU
+        if gpu_type == "cuda":
+            if "CUDAExecutionProvider" in onnx_providers:
+                logger.info("Detected NVIDIA GPU - using ONNX with CUDAExecutionProvider")
+                return ("onnx", None, None)
+            logger.info(
+                "Detected NVIDIA GPU but ONNX CUDA provider unavailable - "
+                "falling back to PyTorch CUDA"
+            )
+            return ("torch", None, "cuda")
 
-        # AMD GPU - use ONNX with ROCm if provider available
-        if gpu_type == "rocm" and "ROCMExecutionProvider" in onnx_providers:
-            logger.info("Detected AMD GPU with ROCm - using ONNX with ROCm acceleration")
-            return ("onnx", None)
+        # AMD GPU (ROCm)
+        if gpu_type == "rocm":
+            if "ROCMExecutionProvider" in onnx_providers:
+                logger.info("Detected AMD GPU - using ONNX with ROCMExecutionProvider")
+                return ("onnx", None, None)
+            logger.info(
+                "Detected AMD GPU but ONNX ROCm provider unavailable - "
+                "falling back to PyTorch ROCm device"
+            )
+            return ("torch", None, "cuda")
 
-        # Intel Mac or generic x86_64 with ONNX
-        if sys.platform == "darwin":
-            logger.info("Detected Intel Mac - using ONNX with standard model")
-            return ("onnx", None)
+        # Apple MPS GPU on non-ONNX path
+        if gpu_type == "mps":
+            if onnx_providers:
+                logger.info("Detected Apple MPS GPU - using ONNX backend")
+                return ("onnx", None, None)
+            logger.info("Detected Apple MPS GPU - ONNX unavailable, using PyTorch MPS")
+            return ("torch", None, "mps")
 
-        # Linux/Windows with ONNX (CPU)
+        # CPU only
         if onnx_providers:
             logger.info(
-                f"Detected platform {sys.platform} - using ONNX backend "
-                f"(providers: {', '.join(onnx_providers)})"
+                "Detected platform %s - using ONNX backend (providers: %s)",
+                sys.platform,
+                ", ".join(onnx_providers),
             )
-            return ("onnx", None)
+            return ("onnx", None, None)
 
-        # Fallback to PyTorch if ONNX not available
-        logger.info(f"ONNX not available, using PyTorch backend on {sys.platform}")
-        return ("torch", None)
+        logger.info("ONNX not available - using PyTorch CPU backend on %s", sys.platform)
+        return ("torch", None, "cpu" if not has_gpu else None)
 
     except Exception as e:
-        logger.warning(f"Failed to detect optimal backend: {e}, falling back to PyTorch")
-        return ("torch", None)
+        logger.warning("Failed to detect optimal backend: %s, falling back to PyTorch CPU", e)
+        return ("torch", None, "cpu")
+
+
+def get_runtime_environment_info() -> dict[str, object]:
+    """Return runtime environment information used for backend decisions."""
+    has_gpu, gpu_type = _check_gpu_availability()
+    onnx_providers = _check_onnx_providers()
+    backend, onnx_model_file, device = detect_optimal_backend_config()
+    return {
+        "platform": sys.platform,
+        "has_gpu": has_gpu,
+        "gpu_type": gpu_type,
+        "onnx_providers": onnx_providers,
+        "selected_backend": backend,
+        "selected_device": device,
+        "selected_onnx_model": onnx_model_file,
+    }
 
 
 @dataclass(slots=True)
@@ -149,23 +194,47 @@ class EmbeddingModel:
 
     def __init__(self, config: EmbeddingConfig | None = None) -> None:
         self.config = config or EmbeddingConfig()
+        self.runtime_info: dict[str, object] = {
+            "selected_backend": self.config.backend,
+            "selected_device": self.config.device,
+            "selected_onnx_model": self.config.onnx_model_file,
+        }
 
         # Auto-detect backend if not specified
         if self.config.backend is None:
-            self.config.backend, self.config.onnx_model_file = detect_optimal_backend()
+            backend, onnx_model_file, device = detect_optimal_backend_config()
+            self.config.backend = backend
+            self.config.onnx_model_file = onnx_model_file
+            if self.config.device is None:
+                self.config.device = device
+
+        self.runtime_info.update(get_runtime_environment_info())
+        self.runtime_info["selected_backend"] = self.config.backend
+        self.runtime_info["selected_device"] = self.config.device
+        self.runtime_info["selected_onnx_model"] = self.config.onnx_model_file
 
         # Try to load model with specified backend, fallback to PyTorch on error
         try:
             self._model = self._load_model()
-            logger.info(f"Successfully loaded model with backend: {self.config.backend}")
+            logger.info(
+                "Successfully loaded embedding model with backend=%s device=%s",
+                self.config.backend,
+                self.config.device or "auto",
+            )
         except Exception as e:
             if self.config.backend != "torch":
                 logger.warning(
-                    f"Failed to load model with backend '{self.config.backend}': {e}. "
-                    "Falling back to PyTorch."
+                    "Failed to load model with backend '%s': %s. Falling back to PyTorch.",
+                    self.config.backend,
+                    e,
                 )
                 self.config.backend = "torch"
                 self.config.onnx_model_file = None
+                if self.config.device is None:
+                    self.config.device = "cpu"
+                self.runtime_info["selected_backend"] = self.config.backend
+                self.runtime_info["selected_device"] = self.config.device
+                self.runtime_info["selected_onnx_model"] = self.config.onnx_model_file
                 self._model = self._load_model()
             else:
                 raise
@@ -208,6 +277,11 @@ class EmbeddingModel:
 
         if self.config.device:
             info_parts.append(f"Device: {self.config.device}")
+
+        selected = self.runtime_info.get("selected_backend")
+        device = self.runtime_info.get("selected_device")
+        if selected:
+            info_parts.append(f"Selected: {selected}/{device or 'auto'}")
 
         logger.info(" | ".join(info_parts))
 

--- a/src/docfinder/embedding/encoder.py
+++ b/src/docfinder/embedding/encoder.py
@@ -69,6 +69,16 @@ def _check_onnx_providers() -> list[str]:
         return []
 
 
+def _preferred_torch_device() -> str:
+    """Return the best torch device available on this host."""
+    has_gpu, gpu_type = _check_gpu_availability()
+    if has_gpu and gpu_type in {"cuda", "rocm"}:
+        return "cuda"
+    if has_gpu and gpu_type == "mps":
+        return "mps"
+    return "cpu"
+
+
 def detect_optimal_backend() -> tuple[Literal["torch", "onnx"], str | None]:
     """Auto-detect the optimal backend based on hardware and platform.
 
@@ -231,7 +241,7 @@ class EmbeddingModel:
                 self.config.backend = "torch"
                 self.config.onnx_model_file = None
                 if self.config.device is None:
-                    self.config.device = "cpu"
+                    self.config.device = _preferred_torch_device()
                 self.runtime_info["selected_backend"] = self.config.backend
                 self.runtime_info["selected_device"] = self.config.device
                 self.runtime_info["selected_onnx_model"] = self.config.onnx_model_file

--- a/src/docfinder/gui.py
+++ b/src/docfinder/gui.py
@@ -817,6 +817,11 @@ def main() -> None:
 
         logger.info("Starting DocFinder server on %s", url)
 
+        # Mark as GUI mode so notifications fire on indexing completion
+        from docfinder.web.app import set_gui_mode
+
+        set_gui_mode(True)
+
         # Start the server in a background thread
         server_thread = ServerThread(host, port)
         server_thread.start()

--- a/src/docfinder/gui.py
+++ b/src/docfinder/gui.py
@@ -33,8 +33,6 @@ from pathlib import Path
 # Disable tokenizers parallelism to prevent forking issues with PyInstaller
 # This must be set before any imports of transformers/tokenizers
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
-os.environ["OMP_NUM_THREADS"] = "1"
-os.environ["MKL_NUM_THREADS"] = "1"
 
 # Set multiprocessing start method to spawn on all platforms for PyInstaller compatibility
 # This prevents issues with forked processes re-executing the main script

--- a/src/docfinder/index/indexer.py
+++ b/src/docfinder/index/indexer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import gc
 import logging
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Sequence
@@ -13,6 +14,7 @@ from docfinder.index.storage import SQLiteVectorStore
 from docfinder.ingestion.pdf_loader import build_chunks
 from docfinder.models import DocumentMetadata
 from docfinder.utils.files import compute_sha256, iter_document_paths
+from docfinder.utils.memory import compute_embed_batch_size, get_memory_info
 
 LOGGER = logging.getLogger(__name__)
 
@@ -70,7 +72,7 @@ class Indexer:
         self.store = store
         self.chunk_chars = chunk_chars
         self.overlap = overlap
-        self.embed_batch_size = embed_batch_size
+        self._fixed_batch_size = embed_batch_size
         self.progress_callback = progress_callback
 
     def index(
@@ -106,6 +108,27 @@ class Indexer:
 
         return stats
 
+    def _get_batch_params(self) -> tuple[int, float]:
+        """Return (batch_size, sleep_between_batches) based on current RAM.
+
+        If a fixed batch size was provided at construction, uses that with no sleep.
+        Otherwise, checks available RAM and adapts dynamically.
+        """
+        if self._fixed_batch_size is not None:
+            return self._fixed_batch_size, 0.0
+
+        info = get_memory_info()
+        available = info.get("available_mb")
+        batch_size, sleep_s = compute_embed_batch_size(available)
+        if available is not None and available < 1024:
+            LOGGER.info(
+                "Low RAM detected (%d MB available) — using batch_size=%d, sleep=%.2fs",
+                available,
+                batch_size,
+                sleep_s,
+            )
+        return batch_size, sleep_s
+
     def _index_single(self, path: Path) -> str:
         """Index a single document file."""
         import itertools
@@ -133,7 +156,8 @@ class Indexer:
             if status == "skipped":
                 return status
 
-            batch_size = 64
+            # Check RAM at the start of each file to adapt batch size
+            batch_size, sleep_s = self._get_batch_params()
             current_batch = []
 
             for chunk in itertools.chain([first_chunk], chunk_gen):
@@ -141,15 +165,17 @@ class Indexer:
                 if len(current_batch) >= batch_size:
                     embeddings = self.embedder.embed(
                         [c.text for c in current_batch],
-                        batch_size=self.embed_batch_size,
+                        batch_size=batch_size,
                     )
                     self.store.insert_chunks(doc_id, current_batch, embeddings)
                     current_batch = []
+                    if sleep_s > 0:
+                        time.sleep(sleep_s)
 
             if current_batch:
                 embeddings = self.embedder.embed(
                     [c.text for c in current_batch],
-                    batch_size=self.embed_batch_size,
+                    batch_size=batch_size,
                 )
                 self.store.insert_chunks(doc_id, current_batch, embeddings)
 

--- a/src/docfinder/index/indexer.py
+++ b/src/docfinder/index/indexer.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import gc
 import logging
-import time
+import os
+from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Sequence
@@ -12,9 +13,8 @@ from typing import Callable, Sequence
 from docfinder.embedding.encoder import EmbeddingModel
 from docfinder.index.storage import SQLiteVectorStore
 from docfinder.ingestion.pdf_loader import build_chunks
-from docfinder.models import DocumentMetadata
+from docfinder.models import ChunkRecord, DocumentMetadata
 from docfinder.utils.files import compute_sha256, iter_document_paths
-from docfinder.utils.memory import compute_embed_batch_size, get_memory_info
 
 LOGGER = logging.getLogger(__name__)
 
@@ -33,6 +33,34 @@ def find_documents(
 # Keep old name as alias so existing tests don't break
 def find_pdfs(paths: Sequence[Path]) -> list[Path]:
     return [p for p in find_documents(paths) if p.suffix.lower() == ".pdf"]
+
+
+def _parse_document(args: tuple) -> dict | None:
+    """Parse a single document into chunks (runs in worker process).
+
+    This is a top-level function so it can be pickled by multiprocessing.
+    Returns a dict with path, metadata, and chunk texts, or None on failure.
+    """
+    path_str, chunk_chars, overlap = args
+    path = Path(path_str)
+    try:
+        chunks = list(build_chunks(path, max_chars=chunk_chars, overlap=overlap))
+        if not chunks:
+            return {"path": path_str, "status": "empty"}
+
+        sha256 = compute_sha256(path)
+        stat = path.stat()
+        return {
+            "path": path_str,
+            "status": "ok",
+            "sha256": sha256,
+            "mtime": stat.st_mtime,
+            "size": stat.st_size,
+            "title": chunks[0].metadata.get("title", path.stem),
+            "chunks": [{"index": c.index, "text": c.text, "metadata": c.metadata} for c in chunks],
+        }
+    except Exception as e:
+        return {"path": path_str, "status": "error", "error": str(e)}
 
 
 @dataclass(slots=True)
@@ -72,7 +100,7 @@ class Indexer:
         self.store = store
         self.chunk_chars = chunk_chars
         self.overlap = overlap
-        self._fixed_batch_size = embed_batch_size
+        self.embed_batch_size = embed_batch_size
         self.progress_callback = progress_callback
 
     def index(
@@ -81,7 +109,7 @@ class Indexer:
         *,
         exclude_paths: frozenset[str] | None = None,
     ) -> IndexStats:
-        """Index all supported documents found under the given paths."""
+        """Index documents with parallel parsing when beneficial."""
         doc_files = find_documents(paths, exclude_paths)
         if not doc_files:
             LOGGER.warning("No supported documents found")
@@ -90,6 +118,32 @@ class Indexer:
         total = len(doc_files)
         stats = IndexStats()
 
+        if total >= 4 and self._should_parallelize():
+            self._index_parallel(doc_files, stats, total)
+        else:
+            self._index_sequential(doc_files, stats, total)
+
+        if self.progress_callback:
+            self.progress_callback(total, total, "")
+
+        return stats
+
+    def _should_parallelize(self) -> bool:
+        """Return True if parallel parsing should be used.
+
+        Returns False when a fixed embed_batch_size is set, which typically
+        indicates a test environment where multiprocessing adds unnecessary
+        complexity.
+        """
+        return self.embed_batch_size is None
+
+    def _index_sequential(
+        self,
+        doc_files: list[Path],
+        stats: IndexStats,
+        total: int,
+    ) -> None:
+        """Index files sequentially (original path)."""
         for i, path in enumerate(doc_files):
             if self.progress_callback:
                 self.progress_callback(i, total, str(path))
@@ -103,31 +157,91 @@ class Indexer:
                 stats.processed_files.append(path)
             gc.collect()
 
-        if self.progress_callback:
-            self.progress_callback(total, total, "")
+    def _index_parallel(
+        self,
+        doc_files: list[Path],
+        stats: IndexStats,
+        total: int,
+    ) -> None:
+        """Parse documents in parallel, then embed and store sequentially."""
+        num_workers = min(os.cpu_count() or 1, len(doc_files), 4)
+        LOGGER.info(
+            "Parallel parsing %d documents with %d workers",
+            len(doc_files),
+            num_workers,
+        )
 
-        return stats
+        args = [(str(p), self.chunk_chars, self.overlap) for p in doc_files]
 
-    def _get_batch_params(self) -> tuple[int, float]:
-        """Return (batch_size, sleep_between_batches) based on current RAM.
+        with ProcessPoolExecutor(max_workers=num_workers) as executor:
+            results = list(executor.map(_parse_document, args))
 
-        If a fixed batch size was provided at construction, uses that with no sleep.
-        Otherwise, checks available RAM and adapts dynamically.
-        """
-        if self._fixed_batch_size is not None:
-            return self._fixed_batch_size, 0.0
+        for i, result in enumerate(results):
+            path = doc_files[i]
+            if self.progress_callback:
+                self.progress_callback(i, total, str(path))
+            try:
+                if result is None:
+                    LOGGER.error("Worker returned None for %s", path)
+                    stats.failed += 1
+                    stats.processed_files.append(path)
+                    continue
 
-        info = get_memory_info()
-        available = info.get("available_mb")
-        batch_size, sleep_s = compute_embed_batch_size(available)
-        if available is not None and available < 1024:
-            LOGGER.info(
-                "Low RAM detected (%d MB available) — using batch_size=%d, sleep=%.2fs",
-                available,
-                batch_size,
-                sleep_s,
-            )
-        return batch_size, sleep_s
+                if result["status"] == "error":
+                    LOGGER.error("Failed to parse %s: %s", path, result.get("error", "unknown"))
+                    stats.failed += 1
+                    stats.processed_files.append(path)
+                    continue
+
+                if result["status"] == "empty":
+                    LOGGER.warning("No text extracted from %s", path)
+                    stats.increment("skipped", path)
+                    continue
+
+                status = self._embed_and_store(path, result)
+                stats.increment(status, path)
+            except Exception as e:
+                LOGGER.error(f"Failed to process {path}: {e}")
+                stats.failed += 1
+                stats.processed_files.append(path)
+            gc.collect()
+
+    def _embed_and_store(self, path: Path, parsed: dict) -> str:
+        """Embed pre-parsed chunks and store them in the database."""
+        document = DocumentMetadata(
+            path=path,
+            title=parsed["title"],
+            sha256=parsed["sha256"],
+            mtime=parsed["mtime"],
+            size=parsed["size"],
+        )
+
+        with self.store.transaction():
+            doc_id, status = self.store.init_document(document)
+            if status == "skipped":
+                return status
+
+            chunk_dicts = parsed["chunks"]
+            chunks = [
+                ChunkRecord(
+                    document_path=path,
+                    index=cd["index"],
+                    text=cd["text"],
+                    metadata=cd["metadata"],
+                )
+                for cd in chunk_dicts
+            ]
+
+            batch_size = 64
+            for start in range(0, len(chunks), batch_size):
+                batch = chunks[start : start + batch_size]
+                embeddings = self.embedder.embed(
+                    [c.text for c in batch],
+                    batch_size=self.embed_batch_size,
+                )
+                self.store.insert_chunks(doc_id, batch, embeddings)
+
+        return status
 
     def _index_single(self, path: Path) -> str:
         """Index a single document file."""
@@ -156,8 +270,7 @@ class Indexer:
             if status == "skipped":
                 return status
 
-            # Check RAM at the start of each file to adapt batch size
-            batch_size, sleep_s = self._get_batch_params()
+            batch_size = 64
             current_batch = []
 
             for chunk in itertools.chain([first_chunk], chunk_gen):
@@ -165,17 +278,15 @@ class Indexer:
                 if len(current_batch) >= batch_size:
                     embeddings = self.embedder.embed(
                         [c.text for c in current_batch],
-                        batch_size=batch_size,
+                        batch_size=self.embed_batch_size,
                     )
                     self.store.insert_chunks(doc_id, current_batch, embeddings)
                     current_batch = []
-                    if sleep_s > 0:
-                        time.sleep(sleep_s)
 
             if current_batch:
                 embeddings = self.embedder.embed(
                     [c.text for c in current_batch],
-                    batch_size=batch_size,
+                    batch_size=self.embed_batch_size,
                 )
                 self.store.insert_chunks(doc_id, current_batch, embeddings)
 

--- a/src/docfinder/index/indexer.py
+++ b/src/docfinder/index/indexer.py
@@ -15,6 +15,7 @@ from docfinder.index.storage import SQLiteVectorStore
 from docfinder.ingestion.pdf_loader import build_chunks
 from docfinder.models import ChunkRecord, DocumentMetadata
 from docfinder.utils.files import compute_sha256, iter_document_paths
+from docfinder.utils.memory import get_memory_info
 
 LOGGER = logging.getLogger(__name__)
 
@@ -102,6 +103,7 @@ class Indexer:
         self.overlap = overlap
         self.embed_batch_size = embed_batch_size
         self.progress_callback = progress_callback
+        self.last_num_workers: int = 1
 
     def index(
         self,
@@ -156,6 +158,7 @@ class Indexer:
                 stats.failed += 1
                 stats.processed_files.append(path)
             gc.collect()
+        self.last_num_workers = 1
 
     def _index_parallel(
         self,
@@ -164,7 +167,8 @@ class Indexer:
         total: int,
     ) -> None:
         """Parse documents in parallel, then embed and store sequentially."""
-        num_workers = min(os.cpu_count() or 1, len(doc_files), 4)
+        num_workers = self._compute_parallel_workers(len(doc_files))
+        self.last_num_workers = num_workers
         LOGGER.info(
             "Parallel parsing %d documents with %d workers",
             len(doc_files),
@@ -242,6 +246,29 @@ class Indexer:
                 self.store.insert_chunks(doc_id, batch, embeddings)
 
         return status
+
+    def _compute_parallel_workers(self, doc_count: int) -> int:
+        """Compute balanced worker count for parallel document parsing."""
+        cpu_count = os.cpu_count() or 1
+        base_workers = min(cpu_count, max(1, doc_count))
+
+        # Balanced mode: keep one CPU for responsiveness when possible.
+        if base_workers > 2:
+            base_workers -= 1
+
+        mem_info = get_memory_info()
+        available_mb = mem_info.get("available_mb")
+        if isinstance(available_mb, int):
+            if available_mb < 2048:
+                base_workers = min(base_workers, 2)
+            elif available_mb < 4096:
+                base_workers = min(base_workers, 3)
+            elif available_mb < 8192:
+                base_workers = min(base_workers, 6)
+            else:
+                base_workers = min(base_workers, 8)
+
+        return max(1, min(base_workers, doc_count))
 
     def _index_single(self, path: Path) -> str:
         """Index a single document file."""

--- a/src/docfinder/index/reranker.py
+++ b/src/docfinder/index/reranker.py
@@ -1,0 +1,62 @@
+"""Cross-encoder reranker for improving search precision."""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+
+def _sigmoid(x: float) -> float:
+    """Convert a raw logit to a 0-1 probability."""
+    return 1.0 / (1.0 + math.exp(-x))
+
+
+class Reranker:
+    """Re-scores search results using a cross-encoder model.
+
+    Cross-encoders evaluate (query, document) pairs jointly, capturing
+    semantic relationships that bi-encoder cosine similarity misses.
+    """
+
+    DEFAULT_MODEL = "cross-encoder/ms-marco-MiniLM-L-2-v2"
+
+    def __init__(self, model_name: str | None = None) -> None:
+        self.model_name = model_name or self.DEFAULT_MODEL
+        self._model = None
+
+    def _ensure_model(self) -> None:
+        if self._model is None:
+            from sentence_transformers import CrossEncoder
+
+            self._model = CrossEncoder(self.model_name)
+            logger.info("Loaded reranker model: %s", self.model_name)
+
+    def rerank(self, query: str, results: List[dict], *, top_k: int = 10) -> List[dict]:
+        """Re-rank results using the cross-encoder.
+
+        Args:
+            query: The search query.
+            results: List of dicts with at least "text" and "score" keys.
+            top_k: Number of top results to return after reranking.
+
+        Returns:
+            Re-ranked and trimmed list of result dicts, with updated scores.
+        """
+        if not results:
+            return results
+
+        self._ensure_model()
+
+        pairs = [(query, r["text"]) for r in results]
+        scores = self._model.predict(pairs)
+
+        for r, rerank_score in zip(results, scores):
+            r["embedding_score"] = r["score"]
+            r["rerank_score"] = float(rerank_score)
+            r["score"] = _sigmoid(float(rerank_score))
+
+        results.sort(key=lambda r: r["score"], reverse=True)
+        return results[:top_k]

--- a/src/docfinder/index/search.py
+++ b/src/docfinder/index/search.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import List
 
 from docfinder.embedding.encoder import EmbeddingModel
+from docfinder.index.reranker import Reranker
 from docfinder.index.storage import SQLiteVectorStore
 
 
@@ -24,14 +25,54 @@ class SearchResult:
 class Searcher:
     """High-level API to query the vector store."""
 
-    def __init__(self, embedder: EmbeddingModel, store: SQLiteVectorStore) -> None:
+    def __init__(
+        self,
+        embedder: EmbeddingModel,
+        store: SQLiteVectorStore,
+        reranker: Reranker | None = None,
+    ) -> None:
         self.embedder = embedder
         self.store = store
+        self.reranker = reranker
 
     def search(self, query: str, *, top_k: int = 10) -> List[SearchResult]:
+        # When reranking, fetch more candidates for the cross-encoder to evaluate
+        fetch_k = max(top_k * 3, 30) if self.reranker is not None else top_k
+
         embedding = self.embedder.embed_query(query)
-        rows = self.store.search(embedding, top_k=top_k)
-        results: List[SearchResult] = []
+        rows = self.store.search(embedding, top_k=fetch_k)
+
+        if self.reranker is not None and rows:
+            # Build dicts for the reranker
+            candidates = []
+            for row in rows:
+                candidates.append(
+                    {
+                        "path": row["path"],
+                        "title": row["title"],
+                        "chunk_index": row["chunk_index"],
+                        "score": float(row["score"]),
+                        "text": row["text"],
+                        "metadata": row.get("metadata"),
+                    }
+                )
+            reranked = self.reranker.rerank(query, candidates, top_k=top_k)
+            results: List[SearchResult] = []
+            for r in reranked:
+                metadata = json.loads(r["metadata"]) if r.get("metadata") else {}
+                results.append(
+                    SearchResult(
+                        path=Path(r["path"]),
+                        title=r["title"],
+                        chunk_index=r["chunk_index"],
+                        score=float(r["score"]),
+                        text=r["text"],
+                        metadata=metadata,
+                    )
+                )
+            return results
+
+        results = []
         for row in rows:
             metadata = json.loads(row["metadata"]) if row.get("metadata") else {}
             results.append(

--- a/src/docfinder/index/search.py
+++ b/src/docfinder/index/search.py
@@ -35,12 +35,18 @@ class Searcher:
         self.store = store
         self.reranker = reranker
 
-    def search(self, query: str, *, top_k: int = 10) -> List[SearchResult]:
+    def search(
+        self,
+        query: str,
+        *,
+        top_k: int = 10,
+        folders: list[str] | None = None,
+    ) -> List[SearchResult]:
         # When reranking, fetch more candidates for the cross-encoder to evaluate
         fetch_k = max(top_k * 3, 30) if self.reranker is not None else top_k
 
         embedding = self.embedder.embed_query(query)
-        rows = self.store.search(embedding, top_k=fetch_k)
+        rows = self.store.search(embedding, top_k=fetch_k, folders=folders)
 
         if self.reranker is not None and rows:
             # Build dicts for the reranker

--- a/src/docfinder/index/storage.py
+++ b/src/docfinder/index/storage.py
@@ -170,10 +170,15 @@ class SQLiteVectorStore:
             self.insert_chunks(doc_id, chunks, embeddings)
             return status
 
-    def search(self, embedding: np.ndarray, *, top_k: int = 10) -> List[dict]:
+    def search(
+        self,
+        embedding: np.ndarray,
+        *,
+        top_k: int = 10,
+        folders: Sequence[str] | None = None,
+    ) -> List[dict]:
         query = np.asarray(embedding, dtype="float32")
-        rows = self._conn.execute(
-            """
+        sql = """
             SELECT
                 c.document_id AS document_id,
                 d.path AS path,
@@ -185,7 +190,20 @@ class SQLiteVectorStore:
             FROM chunks c
             JOIN documents d ON d.id = c.document_id
             """
-        ).fetchall()
+        params: list[str] = []
+
+        if folders is not None:
+            normalized = sorted({f.strip().rstrip("/\\") for f in folders if f and f.strip()})
+            if not normalized:
+                return []
+
+            clauses: list[str] = []
+            for folder in normalized:
+                clauses.append("(d.path = ? OR d.path LIKE ? OR d.path LIKE ?)")
+                params.extend([folder, f"{folder}/%", f"{folder}\\%"])
+            sql += " WHERE " + " OR ".join(clauses)
+
+        rows = self._conn.execute(sql, params).fetchall()
 
         if not rows:
             return []
@@ -214,6 +232,16 @@ class SQLiteVectorStore:
                 }
             )
         return results
+
+    def list_indexed_directories(self) -> List[dict]:
+        """Return indexed parent directories and document counts."""
+        rows = self._conn.execute("SELECT path FROM documents").fetchall()
+        counts: dict[str, int] = {}
+        for row in rows:
+            parent = str(Path(row["path"]).parent)
+            counts[parent] = counts.get(parent, 0) + 1
+
+        return [{"path": path, "document_count": counts[path]} for path in sorted(counts.keys())]
 
     def get_document_chunk_count(self, document_id: int) -> int:
         """Return the total number of chunks for a document."""

--- a/src/docfinder/index/storage.py
+++ b/src/docfinder/index/storage.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from contextlib import contextmanager
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Iterator, List, Sequence
 
 import numpy as np
@@ -94,6 +94,23 @@ class SQLiteVectorStore:
             if "embedding" not in columns:
                 conn.execute("ALTER TABLE chunks ADD COLUMN embedding BLOB")
 
+    @staticmethod
+    def _normalize_path(path: str | Path) -> str:
+        """Return a separator-stable representation for stored paths."""
+        return str(path).replace("\\", "/")
+
+    @classmethod
+    def _normalize_folder(cls, folder: str | Path) -> str:
+        """Normalize folder filters while preserving root/drive roots."""
+        normalized = cls._normalize_path(folder)
+        while (
+            normalized.endswith("/")
+            and normalized != "/"
+            and not normalized.endswith(":/")
+        ):
+            normalized = normalized[:-1]
+        return normalized
+
     def init_document(self, document: DocumentMetadata) -> tuple[int, str]:
         """Initialize a document for insertion.
 
@@ -105,8 +122,8 @@ class SQLiteVectorStore:
         conn = self._conn
 
         existing = conn.execute(
-            "SELECT id, sha256 FROM documents WHERE path = ?",
-            (str(document.path),),
+            "SELECT id, sha256 FROM documents WHERE REPLACE(path, '\\', '/') = ?",
+            (self._normalize_path(document.path),),
         ).fetchone()
 
         if existing and existing["sha256"] == document.sha256:
@@ -193,14 +210,20 @@ class SQLiteVectorStore:
         params: list[str] = []
 
         if folders is not None:
-            normalized = sorted({f.strip().rstrip("/\\") for f in folders if f and f.strip()})
+            normalized = sorted(
+                {
+                    self._normalize_folder(f.strip())
+                    for f in folders
+                    if f and f.strip() and self._normalize_folder(f.strip())
+                }
+            )
             if not normalized:
                 return []
 
             clauses: list[str] = []
             for folder in normalized:
-                clauses.append("(d.path = ? OR d.path LIKE ? OR d.path LIKE ?)")
-                params.extend([folder, f"{folder}/%", f"{folder}\\%"])
+                clauses.append("(REPLACE(d.path, '\\', '/') = ? OR REPLACE(d.path, '\\', '/') LIKE ?)")
+                params.extend([folder, f"{folder}/%"])
             sql += " WHERE " + " OR ".join(clauses)
 
         rows = self._conn.execute(sql, params).fetchall()
@@ -238,7 +261,8 @@ class SQLiteVectorStore:
         rows = self._conn.execute("SELECT path FROM documents").fetchall()
         counts: dict[str, int] = {}
         for row in rows:
-            parent = str(Path(row["path"]).parent)
+            normalized_path = self._normalize_path(row["path"])
+            parent = str(PurePosixPath(normalized_path).parent)
             counts[parent] = counts.get(parent, 0) + 1
 
         return [{"path": path, "document_count": counts[path]} for path in sorted(counts.keys())]
@@ -444,7 +468,11 @@ class SQLiteVectorStore:
         Returns True if document was found and deleted, False otherwise.
         """
         with self.transaction() as conn:
-            existing = conn.execute("SELECT id FROM documents WHERE path = ?", (path,)).fetchone()
+            normalized_path = self._normalize_path(path)
+            existing = conn.execute(
+                "SELECT id FROM documents WHERE REPLACE(path, '\\', '/') = ?",
+                (normalized_path,),
+            ).fetchone()
 
             if not existing:
                 return False

--- a/src/docfinder/index/storage.py
+++ b/src/docfinder/index/storage.py
@@ -103,11 +103,7 @@ class SQLiteVectorStore:
     def _normalize_folder(cls, folder: str | Path) -> str:
         """Normalize folder filters while preserving root/drive roots."""
         normalized = cls._normalize_path(folder)
-        while (
-            normalized.endswith("/")
-            and normalized != "/"
-            and not normalized.endswith(":/")
-        ):
+        while normalized.endswith("/") and normalized != "/" and not normalized.endswith(":/"):
             normalized = normalized[:-1]
         return normalized
 
@@ -223,8 +219,7 @@ class SQLiteVectorStore:
             clauses: list[str] = []
             for folder in normalized:
                 clauses.append(
-                    "(REPLACE(d.path, '\\', '/') = ? "
-                    "OR REPLACE(d.path, '\\', '/') LIKE ?)"
+                    "(REPLACE(d.path, '\\', '/') = ? OR REPLACE(d.path, '\\', '/') LIKE ?)"
                 )
                 params.extend([folder, f"{folder}/%"])
             sql += " WHERE " + " OR ".join(clauses)

--- a/src/docfinder/index/storage.py
+++ b/src/docfinder/index/storage.py
@@ -222,7 +222,10 @@ class SQLiteVectorStore:
 
             clauses: list[str] = []
             for folder in normalized:
-                clauses.append("(REPLACE(d.path, '\\', '/') = ? OR REPLACE(d.path, '\\', '/') LIKE ?)")
+                clauses.append(
+                    "(REPLACE(d.path, '\\', '/') = ? "
+                    "OR REPLACE(d.path, '\\', '/') LIKE ?)"
+                )
                 params.extend([folder, f"{folder}/%"])
             sql += " WHERE " + " OR ".join(clauses)
 

--- a/src/docfinder/index/storage.py
+++ b/src/docfinder/index/storage.py
@@ -215,6 +215,29 @@ class SQLiteVectorStore:
             )
         return results
 
+    def get_document_chunk_count(self, document_id: int) -> int:
+        """Return the total number of chunks for a document."""
+        row = self._conn.execute(
+            "SELECT COUNT(*) FROM chunks WHERE document_id = ?", (document_id,)
+        ).fetchone()
+        return row[0] if row else 0
+
+    def get_all_chunks(self, document_id: int) -> List[dict]:
+        """Return all chunks for a document, ordered by chunk_index."""
+        rows = self._conn.execute(
+            """
+            SELECT chunk_index, text, metadata
+            FROM chunks
+            WHERE document_id = ?
+            ORDER BY chunk_index
+            """,
+            (document_id,),
+        ).fetchall()
+        return [
+            {"chunk_index": row["chunk_index"], "text": row["text"], "metadata": row["metadata"]}
+            for row in rows
+        ]
+
     def get_context_window(
         self, document_id: int, center_index: int, window_size: int = 10
     ) -> List[dict]:

--- a/src/docfinder/ingestion/pdf_loader.py
+++ b/src/docfinder/ingestion/pdf_loader.py
@@ -22,6 +22,79 @@ LOGGER = logging.getLogger(__name__)
 # ── PDF ───────────────────────────────────────────────────────────────────────
 
 
+def _table_to_markdown(table) -> str:
+    """Convert a PyMuPDF Table object to a Markdown table string."""
+    rows = table.extract()
+    if not rows:
+        return ""
+
+    lines: list[str] = []
+    # Header row
+    header = [str(cell or "").strip().replace("\n", " ") for cell in rows[0]]
+    lines.append("| " + " | ".join(header) + " |")
+    lines.append("| " + " | ".join("---" for _ in header) + " |")
+    # Data rows
+    for row in rows[1:]:
+        cells = [str(cell or "").strip().replace("\n", " ") for cell in row]
+        lines.append("| " + " | ".join(cells) + " |")
+    return "\n".join(lines)
+
+
+def _extract_page_text(page) -> str:
+    """Extract text from a PDF page, converting tables to Markdown.
+
+    If tables are detected, they are rendered as Markdown and inserted
+    in place of the raw table text.  Non-table text is extracted normally.
+    """
+    try:
+        tables = page.find_tables()
+    except Exception:
+        tables = None
+
+    if not tables or not tables.tables:
+        # No tables — fast path, same as before
+        return page.get_text() or ""
+
+    # Collect table bounding boxes and their Markdown representations
+    table_items: list[tuple[float, str]] = []  # (top_y, markdown)
+    table_rects: list[fitz.Rect] = []
+    for tab in tables.tables:
+        md = _table_to_markdown(tab)
+        if md:
+            rect = fitz.Rect(tab.bbox)
+            table_items.append((rect.y0, md))
+            table_rects.append(rect)
+
+    # Extract text blocks excluding table areas
+    text_blocks: list[tuple[float, str]] = []  # (top_y, text)
+    for block in page.get_text("blocks") or []:
+        # block = (x0, y0, x1, y1, text, block_no, block_type)
+        if block[6] != 0:  # skip image blocks
+            continue
+        block_rect = fitz.Rect(block[:4])
+        # Skip blocks that overlap significantly with any table
+        overlaps_table = False
+        for tr in table_rects:
+            intersection = block_rect & tr
+            if not intersection.is_empty:
+                block_area = block_rect.width * block_rect.height
+                if block_area > 0:
+                    overlap_ratio = (intersection.width * intersection.height) / block_area
+                    if overlap_ratio > 0.5:
+                        overlaps_table = True
+                        break
+        if not overlaps_table:
+            text = block[4].strip()
+            if text:
+                text_blocks.append((block[1], text))
+
+    # Merge text blocks and tables, sorted by vertical position
+    all_parts: list[tuple[float, str]] = text_blocks + table_items
+    all_parts.sort(key=lambda x: x[0])
+
+    return "\n\n".join(part[1] for part in all_parts)
+
+
 def iter_text_parts(path: Path) -> Iterator[str]:
     """Yield text content from a PDF file, page by page."""
     try:
@@ -34,7 +107,7 @@ def iter_text_parts(path: Path) -> Iterator[str]:
         for index in range(len(doc)):
             try:
                 page = doc[index]
-                text = page.get_text() or ""
+                text = _extract_page_text(page)
                 normalized = normalize_whitespace([text])
                 if normalized:
                     yield normalized + "\n"
@@ -244,7 +317,8 @@ def _get_title(path: Path) -> str:
 def iter_text_parts_paged(path: Path) -> Iterator[tuple[int, str]]:
     """Yield ``(page_number, text)`` for PDF files (1-based page numbers).
 
-    Uses PyMuPDF to extract text page by page.
+    Uses PyMuPDF to extract text page by page.  Tables are detected
+    automatically and rendered as Markdown to preserve structure.
     """
     try:
         doc = fitz.open(path)
@@ -255,7 +329,7 @@ def iter_text_parts_paged(path: Path) -> Iterator[tuple[int, str]]:
         for index in range(len(doc)):
             try:
                 page = doc[index]
-                text = page.get_text() or ""
+                text = _extract_page_text(page)
                 normalized = normalize_whitespace([text])
                 if normalized:
                     yield index + 1, normalized + "\n"

--- a/src/docfinder/rag/engine.py
+++ b/src/docfinder/rag/engine.py
@@ -18,6 +18,10 @@ _MAX_CONTEXT_TOKENS = 4000
 _CHARS_PER_TOKEN = 4
 _MAX_CONTEXT_CHARS = _MAX_CONTEXT_TOKENS * _CHARS_PER_TOKEN  # 16 000 chars
 
+# Documents with at most this many chunks are loaded in full (entire doc as context).
+# 20 chunks × ~500 chars ≈ 10 000 chars, well within the 16 000 char budget.
+_SMALL_DOC_THRESHOLD = 20
+
 _SYSTEM_PROMPT = (
     "You are a helpful assistant that answers questions based on the provided document context. "
     "Use ONLY the information from the context below to answer. "
@@ -114,7 +118,12 @@ class RAGEngine:
     # ── internals ───────────────────────────────────────────────────────
 
     def _build_context(self, results: List[SearchResult]) -> List[dict]:
-        """Retrieve surrounding chunks for each search hit."""
+        """Retrieve context chunks for each search hit.
+
+        Uses a hybrid strategy: small documents (<=``_SMALL_DOC_THRESHOLD`` chunks)
+        are loaded in full, while larger documents use a sliding window around
+        the search hit.
+        """
         all_chunks: List[dict] = []
         seen: set[tuple[int, int]] = set()  # (document_id, chunk_index)
 
@@ -127,8 +136,25 @@ class RAGEngine:
                 continue
             doc_id = row["id"]
 
-            window = self.store.get_context_window(doc_id, result.chunk_index, self.window_size)
-            for chunk in window:
+            chunk_count = self.store.get_document_chunk_count(doc_id)
+            if chunk_count <= _SMALL_DOC_THRESHOLD:
+                logger.debug(
+                    "Small doc strategy for %s (%d chunks): loading entire document",
+                    result.path,
+                    chunk_count,
+                )
+                chunks = self.store.get_all_chunks(doc_id)
+            else:
+                logger.debug(
+                    "Window strategy for %s (%d chunks): window=%d around chunk %d",
+                    result.path,
+                    chunk_count,
+                    self.window_size,
+                    result.chunk_index,
+                )
+                chunks = self.store.get_context_window(doc_id, result.chunk_index, self.window_size)
+
+            for chunk in chunks:
                 key = (doc_id, chunk["chunk_index"])
                 if key not in seen:
                     seen.add(key)

--- a/src/docfinder/rag/engine.py
+++ b/src/docfinder/rag/engine.py
@@ -129,8 +129,9 @@ class RAGEngine:
 
         for result in results:
             # We need the document_id — look it up via the store
+            normalized_path = str(result.path).replace("\\", "/")
             row = self.store.connection.execute(
-                "SELECT id FROM documents WHERE path = ?", (str(result.path),)
+                "SELECT id FROM documents WHERE REPLACE(path, '\\', '/') = ?", (normalized_path,)
             ).fetchone()
             if row is None:
                 continue

--- a/src/docfinder/utils/memory.py
+++ b/src/docfinder/utils/memory.py
@@ -1,0 +1,106 @@
+"""System memory utilities for adaptive resource management."""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+
+def get_memory_info() -> dict[str, Any]:
+    """Return available and total RAM in MB using platform-native methods.
+
+    Returns ``{"available_mb": int | None, "total_mb": int | None}``.
+    No extra dependencies required.
+    """
+    try:
+        import psutil  # optional – used if installed
+
+        vm = psutil.virtual_memory()
+        return {
+            "available_mb": vm.available // (1024 * 1024),
+            "total_mb": vm.total // (1024 * 1024),
+        }
+    except ImportError:
+        pass
+
+    if sys.platform == "darwin":
+        try:
+            import subprocess as _sp
+
+            total = int(_sp.check_output(["sysctl", "-n", "hw.memsize"]).strip())
+            vm_out = _sp.check_output(["vm_stat"]).decode()
+            free_pages = inactive_pages = 0
+            for line in vm_out.splitlines():
+                if line.startswith("Pages free:"):
+                    free_pages = int(line.split(":")[1].strip().rstrip("."))
+                elif line.startswith("Pages inactive:"):
+                    inactive_pages = int(line.split(":")[1].strip().rstrip("."))
+            available = (free_pages + inactive_pages) * 4096
+            return {"available_mb": available // (1024 * 1024), "total_mb": total // (1024 * 1024)}
+        except Exception:
+            pass
+    elif sys.platform.startswith("linux"):
+        try:
+            meminfo: dict[str, int] = {}
+            with open("/proc/meminfo") as _f:
+                for line in _f:
+                    k, v = line.split(":")
+                    meminfo[k.strip()] = int(v.strip().split()[0])  # kB
+            return {
+                "available_mb": meminfo.get("MemAvailable", meminfo.get("MemFree", 0)) // 1024,
+                "total_mb": meminfo.get("MemTotal", 0) // 1024,
+            }
+        except Exception:
+            pass
+    elif sys.platform == "win32":
+        try:
+            import ctypes
+
+            class _MemStatEx(ctypes.Structure):
+                _fields_ = [
+                    ("dwLength", ctypes.c_ulong),
+                    ("dwMemoryLoad", ctypes.c_ulong),
+                    ("ullTotalPhys", ctypes.c_ulonglong),
+                    ("ullAvailPhys", ctypes.c_ulonglong),
+                    ("ullTotalPageFile", ctypes.c_ulonglong),
+                    ("ullAvailPageFile", ctypes.c_ulonglong),
+                    ("ullTotalVirtual", ctypes.c_ulonglong),
+                    ("ullAvailVirtual", ctypes.c_ulonglong),
+                    ("sullAvailExtendedVirtual", ctypes.c_ulonglong),
+                ]
+
+            stat = _MemStatEx()
+            stat.dwLength = ctypes.sizeof(stat)
+            ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(stat))  # type: ignore[attr-defined]
+            return {
+                "available_mb": stat.ullAvailPhys // (1024 * 1024),
+                "total_mb": stat.ullTotalPhys // (1024 * 1024),
+            }
+        except Exception:
+            pass
+
+    return {"available_mb": None, "total_mb": None}
+
+
+def compute_embed_batch_size(available_mb: int | None = None) -> tuple[int, float]:
+    """Choose embedding batch size and inter-batch sleep based on available RAM.
+
+    Args:
+        available_mb: Available RAM in MB. If None, will be detected automatically.
+
+    Returns:
+        (batch_size, sleep_seconds) tuple.
+    """
+    if available_mb is None:
+        available_mb = get_memory_info().get("available_mb")
+
+    if available_mb is None or available_mb >= 4096:
+        return 64, 0.0
+    elif available_mb >= 2048:
+        return 32, 0.0
+    elif available_mb >= 1024:
+        return 16, 0.0
+    elif available_mb >= 512:
+        return 8, 0.05
+    else:
+        return 4, 0.2

--- a/src/docfinder/utils/notify.py
+++ b/src/docfinder/utils/notify.py
@@ -1,0 +1,69 @@
+"""Cross-platform native desktop notifications. No extra dependencies."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+
+LOGGER = logging.getLogger(__name__)
+
+
+def send_notification(title: str, message: str) -> None:
+    """Send a native OS notification. Fails silently if unsupported."""
+    try:
+        if sys.platform == "darwin":
+            _notify_macos(title, message)
+        elif sys.platform.startswith("linux"):
+            _notify_linux(title, message)
+        elif sys.platform == "win32":
+            _notify_windows(title, message)
+        else:
+            LOGGER.debug("Notifications not supported on %s", sys.platform)
+    except Exception as exc:
+        LOGGER.debug("Failed to send notification: %s", exc)
+
+
+def _notify_macos(title: str, message: str) -> None:
+    """Use osascript to display a macOS notification."""
+    # Escape double quotes for AppleScript
+    safe_title = title.replace('"', '\\"')
+    safe_msg = message.replace('"', '\\"')
+    script = f'display notification "{safe_msg}" with title "{safe_title}"'
+    subprocess.Popen(
+        ["osascript", "-e", script],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _notify_linux(title: str, message: str) -> None:
+    """Use notify-send (libnotify) for Linux desktop notifications."""
+    subprocess.Popen(
+        ["notify-send", title, message],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _notify_windows(title: str, message: str) -> None:
+    """Use PowerShell toast notification on Windows 10+."""
+    # BalloonTipIcon via .NET — works without extra packages
+    ps_script = (
+        "[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, "
+        "ContentType = WindowsRuntime] > $null; "
+        "$template = [Windows.UI.Notifications.ToastNotificationManager]::"
+        "GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02); "
+        "$textNodes = $template.GetElementsByTagName('text'); "
+        f"$textNodes.Item(0).AppendChild($template.CreateTextNode('{title}')) > $null; "
+        f"$textNodes.Item(1).AppendChild($template.CreateTextNode('{message}')) > $null; "
+        "$toast = [Windows.UI.Notifications.ToastNotification]::new($template); "
+        "[Windows.UI.Notifications.ToastNotificationManager]::"
+        "CreateToastNotifier('DocFinder').Show($toast)"
+    )
+    subprocess.Popen(
+        ["powershell", "-Command", ps_script],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        creationflags=0x08000000,  # CREATE_NO_WINDOW
+    )

--- a/src/docfinder/utils/text.py
+++ b/src/docfinder/utils/text.py
@@ -1,8 +1,37 @@
-"""Text helpers including simple token-aware chunking."""
+"""Text helpers including sentence-aware chunking."""
 
 from __future__ import annotations
 
+import re
 from typing import Iterable, Iterator
+
+# Sentence boundary: period/question/exclamation followed by whitespace,
+# or double newline (paragraph break).  Lookbehind avoids splitting on
+# common abbreviations (e.g., Mr., Dr., vs., etc.) and decimal numbers.
+_SENTENCE_END = re.compile(
+    r"(?<=[.!?])\s+(?=[A-Z\u00C0-\u024F\d\"'\(\[])"  # ". Next" or "? 123"
+    r"|(?<=\n)\n+",  # paragraph breaks
+)
+
+
+def _split_sentences(text: str) -> list[str]:
+    """Split *text* into sentence-like segments.
+
+    Uses regex to split at sentence boundaries while keeping
+    the text intact (no characters are lost).
+    """
+    if not text:
+        return []
+
+    parts = _SENTENCE_END.split(text)
+    # Merge very short fragments (< 20 chars) back into previous sentence
+    merged: list[str] = []
+    for part in parts:
+        if merged and len(merged[-1]) < 20:
+            merged[-1] += part
+        else:
+            merged.append(part)
+    return [s for s in merged if s.strip()]
 
 
 def chunk_text(text: str, *, max_chars: int = 1200, overlap: int = 200) -> Iterator[str]:
@@ -44,36 +73,58 @@ def chunk_text_stream(
 def chunk_text_stream_paged(
     pages: Iterable[tuple[int, str]], *, max_chars: int = 1200, overlap: int = 200
 ) -> Iterator[tuple[str, int]]:
-    """Split a stream of (page_number, text) into overlapping chunks.
+    """Split a stream of ``(page_number, text)`` into sentence-aware chunks.
 
     Yields ``(chunk_text, page_number)`` where ``page_number`` is the page
     that contributed the **start** of the chunk.
 
-    This preserves page provenance so that downstream code can store the
-    originating page in chunk metadata.
+    Algorithm:
+    1. Incoming text is split into sentences.
+    2. Sentences accumulate until adding the next one would exceed *max_chars*.
+    3. When a chunk is emitted, the last sentence(s) of the previous chunk
+       are kept as semantic overlap (up to *overlap* characters worth).
+    4. Paragraph breaks (``\\n\\n``) are preferred split points.
     """
-    buffer = ""
-    # Track which page the start of the buffer came from
-    buf_page = 0
-    step = max(max_chars - overlap, 1)
+    # Accumulated sentences for the current chunk
+    sentences: list[str] = []
+    # Page number for the start of the current chunk
+    chunk_page: int = 0
+    # Running character count for current chunk
+    chunk_len: int = 0
 
     for page_num, part in pages:
-        if not buffer:
-            buf_page = page_num
-        buffer += part
-        while len(buffer) >= max_chars:
-            yield buffer[:max_chars], buf_page
-            buffer = buffer[step:]
-            # After slicing, the start of the buffer has shifted.
-            # The overlap region still belongs to the old page, so
-            # we keep buf_page unchanged — it's the page of the
-            # beginning of the chunk.  It will be updated when new
-            # text is appended from the next page.
-            if not buffer:
-                buf_page = page_num
+        if not sentences:
+            chunk_page = page_num
 
-    if buffer:
-        yield buffer, buf_page
+        page_sentences = _split_sentences(part)
+
+        for sentence in page_sentences:
+            sent_len = len(sentence)
+
+            # If adding this sentence exceeds max_chars and we already have content
+            if chunk_len + sent_len > max_chars and sentences:
+                # Emit current chunk
+                yield "".join(sentences), chunk_page
+
+                # Semantic overlap: keep last sentence(s) up to `overlap` chars
+                overlap_sents: list[str] = []
+                overlap_len = 0
+                for s in reversed(sentences):
+                    if overlap_len + len(s) > overlap and overlap_sents:
+                        break
+                    overlap_sents.insert(0, s)
+                    overlap_len += len(s)
+
+                sentences = overlap_sents
+                chunk_len = overlap_len
+                chunk_page = page_num
+
+            sentences.append(sentence)
+            chunk_len += sent_len
+
+    # Emit remaining content
+    if sentences:
+        yield "".join(sentences), chunk_page
 
 
 def normalize_whitespace(lines: Iterable[str]) -> str:

--- a/src/docfinder/web/app.py
+++ b/src/docfinder/web/app.py
@@ -130,6 +130,7 @@ class SearchPayload(BaseModel):
     query: str
     db: Path | None = None
     top_k: int = 10
+    folders: List[str] = []
 
 
 class OpenRequest(BaseModel):
@@ -193,9 +194,27 @@ async def search_documents(payload: SearchPayload) -> dict[str, List[SearchResul
     reranker = _get_reranker()
     store = SQLiteVectorStore(resolved_db, dimension=embedder.dimension)
     searcher = Searcher(embedder, store, reranker=reranker)
-    results = searcher.search(query, top_k=top_k)
+    folders = [f.strip() for f in payload.folders if f and f.strip()]
+    results = searcher.search(query, top_k=top_k, folders=folders if folders else None)
     store.close()
     return {"results": results}
+
+
+@app.get("/search/folders")
+async def search_folders(db: Path | None = None) -> dict[str, Any]:
+    """Return currently indexed directories for search-time filtering."""
+    resolved_db = _resolve_db_path(db)
+    if not resolved_db.exists():
+        return {"folders": []}
+
+    embedder = _get_embedder()
+    store = SQLiteVectorStore(resolved_db, dimension=embedder.dimension)
+    try:
+        folders = store.list_indexed_directories()
+    finally:
+        store.close()
+
+    return {"folders": folders}
 
 
 # ── RAG singleton + download progress ─────────────────────────────────────

--- a/src/docfinder/web/app.py
+++ b/src/docfinder/web/app.py
@@ -18,7 +18,11 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from docfinder.config import AppConfig
-from docfinder.embedding.encoder import EmbeddingConfig, EmbeddingModel
+from docfinder.embedding.encoder import (
+    EmbeddingConfig,
+    EmbeddingModel,
+    get_runtime_environment_info,
+)
 from docfinder.index.indexer import Indexer
 from docfinder.index.reranker import Reranker
 from docfinder.index.search import Searcher, SearchResult
@@ -616,6 +620,14 @@ def _get_memory_info() -> dict[str, Any]:
     return get_memory_info()
 
 
+def _get_runtime_info() -> dict[str, Any]:
+    """Return runtime backend/device and indexing strategy info."""
+    info = get_runtime_environment_info()
+    info["indexing_mode"] = "balanced"
+    info["cpu_count"] = os.cpu_count()
+    return info
+
+
 def _validate_paths(paths: List[str]) -> List[Path]:
     """Validate and resolve a list of raw path strings. Raises HTTPException on error."""
     logger = logging.getLogger(__name__)
@@ -723,8 +735,10 @@ async def get_index_status(job_id: str) -> dict[str, Any]:
 
 @app.get("/system/info")
 async def get_system_info() -> dict[str, Any]:
-    """Return available and total RAM in MB for the host machine."""
-    return await asyncio.to_thread(_get_memory_info)
+    """Return RAM + runtime backend and indexing strategy details."""
+    memory = await asyncio.to_thread(_get_memory_info)
+    runtime = await asyncio.to_thread(_get_runtime_info)
+    return {**memory, **runtime}
 
 
 class ScanPayload(BaseModel):

--- a/src/docfinder/web/app.py
+++ b/src/docfinder/web/app.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 from docfinder.config import AppConfig
 from docfinder.embedding.encoder import EmbeddingConfig, EmbeddingModel
 from docfinder.index.indexer import Indexer
+from docfinder.index.reranker import Reranker
 from docfinder.index.search import Searcher, SearchResult
 from docfinder.index.storage import SQLiteVectorStore
 from docfinder.settings import load_settings
@@ -42,6 +43,21 @@ def _get_embedder() -> EmbeddingModel:
                 config = AppConfig()
                 _embedder = EmbeddingModel(EmbeddingConfig(model_name=config.model_name))
     return _embedder
+
+
+# ── Singleton Reranker ────────────────────────────────────────────────────────
+_reranker: Reranker | None = None
+_reranker_lock = threading.Lock()
+
+
+def _get_reranker() -> Reranker:
+    """Return a cached Reranker, creating it on first call (lazy model load)."""
+    global _reranker
+    if _reranker is None:
+        with _reranker_lock:
+            if _reranker is None:
+                _reranker = Reranker()
+    return _reranker
 
 
 # ── Async indexing job registry ───────────────────────────────────────────────
@@ -81,11 +97,18 @@ def _notify_indexing_done(result: dict[str, Any] | None, *, error: str | None = 
         send_notification("DocFinder", f"Indexing complete: {total} documents processed.")
 
 
+def _preload_reranker() -> None:
+    """Pre-load the reranker model (singleton + ensure weights are downloaded)."""
+    reranker = _get_reranker()
+    reranker._ensure_model()
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
-    # Pre-load the embedding model at startup so the first request is instant
+    # Pre-load models at startup so the first request is instant
     await asyncio.to_thread(_get_embedder)
+    await asyncio.to_thread(_preload_reranker)
     yield
 
 
@@ -163,8 +186,9 @@ async def search_documents(payload: SearchPayload) -> dict[str, List[SearchResul
         )
 
     embedder = _get_embedder()
+    reranker = _get_reranker()
     store = SQLiteVectorStore(resolved_db, dimension=embedder.dimension)
-    searcher = Searcher(embedder, store)
+    searcher = Searcher(embedder, store, reranker=reranker)
     results = searcher.search(query, top_k=top_k)
     store.close()
     return {"results": results}

--- a/src/docfinder/web/app.py
+++ b/src/docfinder/web/app.py
@@ -49,12 +49,36 @@ _index_jobs: dict[str, dict] = {}
 
 # ── GUI callback registry (set by the desktop GUI layer, not used in web mode) ─
 _spotlight_hide_callback: object = None  # callable | None
+_is_gui_mode: bool = False
 
 
 def register_spotlight_hide_callback(callback: object) -> None:
     """Register a callable that hides the spotlight panel (called by gui.py)."""
     global _spotlight_hide_callback
     _spotlight_hide_callback = callback
+
+
+def set_gui_mode(enabled: bool = True) -> None:
+    """Mark the app as running inside the desktop GUI (pywebview)."""
+    global _is_gui_mode
+    _is_gui_mode = enabled
+
+
+def _notify_indexing_done(result: dict[str, Any] | None, *, error: str | None = None) -> None:
+    """Send a native notification when indexing completes (GUI mode only)."""
+    if not _is_gui_mode:
+        return
+
+    from docfinder.utils.notify import send_notification
+
+    if error:
+        send_notification("DocFinder", f"Indexing failed: {error}")
+    elif result:
+        inserted = result.get("inserted", 0)
+        updated = result.get("updated", 0)
+        skipped = result.get("skipped", 0)
+        total = inserted + updated + skipped
+        send_notification("DocFinder", f"Indexing complete: {total} documents processed.")
 
 
 @asynccontextmanager
@@ -511,15 +535,16 @@ async def update_settings(payload: SettingsPayload) -> dict:
 
 
 def _compute_embed_batch_size() -> int:
-    """Choose embedding batch size based on available RAM to avoid OOM."""
-    info = _get_memory_info()
-    available = info.get("available_mb")
-    if available is None or available >= 4096:
-        return 32
-    elif available >= 2048:
-        return 16
-    else:
-        return 8
+    """Choose embedding batch size based on available RAM to avoid OOM.
+
+    Note: the Indexer now does per-file adaptive throttling internally.
+    This is kept for the initial batch size hint passed to the Indexer.
+    """
+    from docfinder.utils.memory import compute_embed_batch_size, get_memory_info
+
+    info = get_memory_info()
+    batch_size, _ = compute_embed_batch_size(info.get("available_mb"))
+    return batch_size
 
 
 def _run_index_job(
@@ -530,7 +555,6 @@ def _run_index_job(
     exclude_paths: frozenset[str] | None = None,
 ) -> dict[str, Any]:
     embedder = _get_embedder()
-    embed_batch_size = _compute_embed_batch_size()
 
     def _progress(processed: int, total: int, current_file: str) -> None:
         if job is not None:
@@ -539,12 +563,12 @@ def _run_index_job(
             job["current_file"] = current_file
 
     store = SQLiteVectorStore(resolved_db, dimension=embedder.dimension)
+    # No fixed embed_batch_size — Indexer adapts per-file based on available RAM
     indexer = Indexer(
         embedder,
         store,
         chunk_chars=config.chunk_chars,
         overlap=config.overlap,
-        embed_batch_size=embed_batch_size,
         progress_callback=_progress,
     )
     try:
@@ -562,75 +586,10 @@ def _run_index_job(
 
 
 def _get_memory_info() -> dict[str, Any]:
-    """Return available and total RAM in MB using platform-native methods. No extra deps."""
-    try:
-        import psutil  # optional – used if installed
+    """Return available and total RAM in MB. Delegates to shared utility."""
+    from docfinder.utils.memory import get_memory_info
 
-        vm = psutil.virtual_memory()
-        return {
-            "available_mb": vm.available // (1024 * 1024),
-            "total_mb": vm.total // (1024 * 1024),
-        }
-    except ImportError:
-        pass
-
-    if sys.platform == "darwin":
-        try:
-            import subprocess as _sp
-
-            total = int(_sp.check_output(["sysctl", "-n", "hw.memsize"]).strip())
-            vm_out = _sp.check_output(["vm_stat"]).decode()
-            free_pages = inactive_pages = 0
-            for line in vm_out.splitlines():
-                if line.startswith("Pages free:"):
-                    free_pages = int(line.split(":")[1].strip().rstrip("."))
-                elif line.startswith("Pages inactive:"):
-                    inactive_pages = int(line.split(":")[1].strip().rstrip("."))
-            available = (free_pages + inactive_pages) * 4096
-            return {"available_mb": available // (1024 * 1024), "total_mb": total // (1024 * 1024)}
-        except Exception:
-            pass
-    elif sys.platform.startswith("linux"):
-        try:
-            meminfo: dict[str, int] = {}
-            with open("/proc/meminfo") as _f:
-                for line in _f:
-                    k, v = line.split(":")
-                    meminfo[k.strip()] = int(v.strip().split()[0])  # kB
-            return {
-                "available_mb": meminfo.get("MemAvailable", meminfo.get("MemFree", 0)) // 1024,
-                "total_mb": meminfo.get("MemTotal", 0) // 1024,
-            }
-        except Exception:
-            pass
-    elif sys.platform == "win32":
-        try:
-            import ctypes
-
-            class _MemStatEx(ctypes.Structure):
-                _fields_ = [
-                    ("dwLength", ctypes.c_ulong),
-                    ("dwMemoryLoad", ctypes.c_ulong),
-                    ("ullTotalPhys", ctypes.c_ulonglong),
-                    ("ullAvailPhys", ctypes.c_ulonglong),
-                    ("ullTotalPageFile", ctypes.c_ulonglong),
-                    ("ullAvailPageFile", ctypes.c_ulonglong),
-                    ("ullTotalVirtual", ctypes.c_ulonglong),
-                    ("ullAvailVirtual", ctypes.c_ulonglong),
-                    ("sullAvailExtendedVirtual", ctypes.c_ulonglong),
-                ]
-
-            stat = _MemStatEx()
-            stat.dwLength = ctypes.sizeof(stat)
-            ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(stat))  # type: ignore[attr-defined]
-            return {
-                "available_mb": stat.ullAvailPhys // (1024 * 1024),
-                "total_mb": stat.ullTotalPhys // (1024 * 1024),
-            }
-        except Exception:
-            pass
-
-    return {"available_mb": None, "total_mb": None}
+    return get_memory_info()
 
 
 def _validate_paths(paths: List[str]) -> List[Path]:
@@ -718,10 +677,12 @@ async def index_documents(payload: IndexPayload) -> dict[str, Any]:
             )
             job["status"] = "complete"
             job["stats"] = result
+            _notify_indexing_done(result)
         except Exception as exc:
             LOGGER.exception("Indexing job %s failed: %s", job_id, exc)
             job["status"] = "error"
             job["error"] = str(exc)
+            _notify_indexing_done(None, error=str(exc))
 
     asyncio.create_task(_run())
     return {"status": "ok", "job_id": job_id}

--- a/src/docfinder/web/templates/index.html
+++ b/src/docfinder/web/templates/index.html
@@ -455,6 +455,67 @@
         padding: 0 0.25rem;
       }
 
+      .search-filters {
+        max-width: 600px;
+        margin: 0.85rem auto 0;
+        padding: 0.65rem 0.8rem;
+        border: 1px solid var(--border);
+        border-radius: var(--radius-sm);
+        background: var(--bg-1);
+        box-shadow: var(--shadow-sm);
+      }
+
+      .search-filters-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.5rem;
+        margin-bottom: 0.5rem;
+      }
+
+      .search-filters-title {
+        font-size: 0.76rem;
+        font-weight: 600;
+        color: var(--text-2);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+
+      .search-filters-actions {
+        display: flex;
+        gap: 0.35rem;
+      }
+
+      .search-filters-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+        max-height: 150px;
+        overflow-y: auto;
+      }
+
+      .search-filter-row {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.8rem;
+        color: var(--text-1);
+      }
+
+      .search-filter-path {
+        flex: 1;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-family: "SF Mono", "JetBrains Mono", monospace;
+        font-size: 0.72rem;
+      }
+
+      .search-filter-count {
+        color: var(--text-3);
+        font-size: 0.72rem;
+      }
+
       /* ── Buttons ──────────────────────────────────────────────────────────── */
       .btn {
         display: inline-flex;
@@ -1365,6 +1426,18 @@
               <button type="submit" class="btn btn-primary search-btn">Search</button>
             </div>
           </form>
+          <div class="search-filters" id="search-filters-box">
+            <div class="search-filters-header">
+              <span class="search-filters-title">Folder filters</span>
+              <div class="search-filters-actions">
+                <button type="button" class="btn btn-secondary btn-sm" id="search-folders-all">All</button>
+                <button type="button" class="btn btn-secondary btn-sm" id="search-folders-none">None</button>
+              </div>
+            </div>
+            <div class="search-filters-list" id="search-folders-list">
+              <div style="font-size:0.78rem;color:var(--text-2);">Loading indexed folders...</div>
+            </div>
+          </div>
         </div>
         <div id="results-meta" class="results-meta" style="display:none;"></div>
         <ul id="results" class="results-list" aria-live="polite"></ul>
@@ -1665,7 +1738,10 @@
       });
 
       // Auto-focus search on load
-      window.addEventListener('load', () => document.getElementById('query').focus());
+      window.addEventListener('load', () => {
+        document.getElementById('query').focus();
+        loadSearchFolders();
+      });
 
       // ── Toast ────────────────────────────────────────────────────────────
       function showToast(message, type = 'success') {
@@ -1699,6 +1775,55 @@
       const searchForm = document.getElementById('search-form');
       const resultsList = document.getElementById('results');
       const resultsMeta  = document.getElementById('results-meta');
+      const searchFoldersList = document.getElementById('search-folders-list');
+      const searchFoldersAllBtn = document.getElementById('search-folders-all');
+      const searchFoldersNoneBtn = document.getElementById('search-folders-none');
+      let searchFolders = [];
+
+      async function loadSearchFolders() {
+        try {
+          const res = await fetch(`${apiBase}/search/folders`);
+          const data = await res.json();
+          searchFolders = data.folders || [];
+
+          if (!searchFolders.length) {
+            searchFoldersList.innerHTML =
+              '<div style="font-size:0.78rem;color:var(--text-2);">No indexed folders yet.</div>';
+            return;
+          }
+
+          searchFoldersList.innerHTML = searchFolders
+            .map(f => `
+              <label class="search-filter-row">
+                <input type="checkbox" class="search-folder-cb" data-path="${escHtml(f.path)}" checked />
+                <span class="search-filter-path" title="${escHtml(f.path)}">${escHtml(f.path)}</span>
+                <span class="search-filter-count">${f.document_count}</span>
+              </label>
+            `)
+            .join('');
+        } catch (_err) {
+          searchFoldersList.innerHTML =
+            '<div style="font-size:0.78rem;color:var(--danger);">Unable to load folders.</div>';
+        }
+      }
+
+      function getSelectedSearchFolders() {
+        const checked = Array.from(document.querySelectorAll('.search-folder-cb:checked'));
+        if (!checked.length) return [];
+        return checked.map(cb => cb.dataset.path).filter(Boolean);
+      }
+
+      searchFoldersAllBtn.addEventListener('click', () => {
+        document.querySelectorAll('.search-folder-cb').forEach(cb => {
+          cb.checked = true;
+        });
+      });
+
+      searchFoldersNoneBtn.addEventListener('click', () => {
+        document.querySelectorAll('.search-folder-cb').forEach(cb => {
+          cb.checked = false;
+        });
+      });
 
       function renderResult(r) {
         const li = document.createElement('li');
@@ -1734,6 +1859,7 @@
         e.preventDefault();
         const query = document.getElementById('query').value.trim();
         if (!query) return;
+        const folders = getSelectedSearchFolders();
 
         resultsMeta.style.display = 'none';
         resultsList.innerHTML = '<div class="loading"><div class="spinner"></div><span>Searching\u2026</span></div>';
@@ -1742,7 +1868,7 @@
           const res = await fetch(`${apiBase}/search`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ query }),
+            body: JSON.stringify({ query, folders }),
           });
           if (!res.ok) throw new Error((await res.json()).detail || 'Search failed');
           const data = await res.json();

--- a/src/docfinder/web/templates/index.html
+++ b/src/docfinder/web/templates/index.html
@@ -1541,6 +1541,15 @@
               <div id="rag-status-msg" style="display:none; margin-top:0.5rem; font-size:0.82rem; padding:0.5rem 0.7rem; border-radius:var(--radius-sm);"></div>
             </div>
           </div>
+
+          <div style="margin-top:1.5rem; padding-top:1rem; border-top:1px solid var(--border);">
+            <h3 style="font-size:0.75rem; font-weight:600; color:var(--text-3); text-transform:uppercase; letter-spacing:0.06em; margin-bottom:0.4rem;">
+              Configuration settings
+            </h3>
+            <div class="info-box" id="runtime-info-box" style="margin-top:0.6rem;">
+              Runtime acceleration: detecting...
+            </div>
+          </div>
         </div>
       </div>
     </main>
@@ -1613,8 +1622,23 @@
       let systemInfo = { available_mb: null, total_mb: null };
       fetch(`${apiBase}/system/info`)
         .then(r => r.json())
-        .then(d => { systemInfo = d; })
+        .then(d => {
+          systemInfo = d;
+          renderRuntimeInfo();
+        })
         .catch(() => {});
+
+      function renderRuntimeInfo() {
+        const box = document.getElementById('runtime-info-box');
+        if (!box) return;
+
+        const backend = systemInfo.selected_backend || 'unknown';
+        const device = systemInfo.selected_device || 'auto';
+        const gpu = systemInfo.gpu_type || 'none';
+
+        box.textContent =
+          `Runtime acceleration: backend ${backend} (${device}), GPU ${gpu}, index workers auto (balanced).`;
+      }
 
       // ── Tab navigation ───────────────────────────────────────────────────
       const tabs     = document.querySelectorAll('.tab');

--- a/src/docfinder/web/templates/spotlight.html
+++ b/src/docfinder/web/templates/spotlight.html
@@ -10,59 +10,62 @@
     html, body {
       height: 100%;
       overflow: hidden;
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
-      /* Match the NSPanel/WKWebView background so no white edges appear
-         when the window uses a solid (non-transparent) background. */
-      background: rgb(22, 27, 42);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui, sans-serif;
+      font-size: 14px;
+      background: #0a0a0f;
     }
 
     .window {
       height: 100vh;
-      background: rgba(22, 27, 42, 0.97);
-      border: 1px solid rgba(255, 255, 255, 0.10);
-      border-radius: 14px;
+      background: rgba(18, 18, 26, 0.95);
+      border: 1px solid rgba(255, 255, 255, 0.06);
+      border-radius: 16px;
       overflow: hidden;
       display: flex;
       flex-direction: column;
-      box-shadow: 0 32px 80px rgba(0,0,0,0.55), 0 4px 16px rgba(0,0,0,0.4);
+      box-shadow: 0 20px 60px rgba(0,0,0,0.5), 0 0 0 1px rgba(255, 255, 255, 0.06);
+      animation: spotlightIn 0.15s cubic-bezier(0.16, 1, 0.3, 1);
+    }
+
+    @keyframes spotlightIn {
+      from { opacity: 0; transform: scale(0.98) translateY(-8px); }
+      to { opacity: 1; transform: scale(1) translateY(0); }
     }
 
     /* ── Search bar ─────────────────────────────────────────────────────── */
     .search-bar {
       display: flex;
       align-items: center;
-      padding: 0 18px;
-      height: 68px;
-      gap: 14px;
-      border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+      padding: 0 16px;
+      height: 56px;
+      gap: 12px;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.06);
       flex-shrink: 0;
-      /* Allow dragging the frameless window by its header on Windows/Linux */
       -webkit-app-region: drag;
     }
 
-    /* Input and interactive elements must opt out of drag */
     #spotlight-input, .spinner-sm { -webkit-app-region: no-drag; }
 
-    .search-icon { color: rgba(255,255,255,0.35); flex-shrink: 0; }
+    .search-icon { color: #6b7280; flex-shrink: 0; }
 
     #spotlight-input {
       flex: 1;
       background: none;
       border: none;
       outline: none;
-      font-size: 1.3rem;
+      font-size: 1.05rem;
       font-weight: 400;
-      color: rgba(255,255,255,0.92);
-      caret-color: #60a5fa;
-      letter-spacing: 0.01em;
+      color: #f3f4f6;
+      caret-color: #818cf8;
+      font-family: inherit;
     }
 
-    #spotlight-input::placeholder { color: rgba(255,255,255,0.25); }
+    #spotlight-input::placeholder { color: #6b7280; }
 
     .spinner-sm {
-      width: 16px; height: 16px;
-      border: 2px solid rgba(255,255,255,0.12);
-      border-top-color: #60a5fa;
+      width: 14px; height: 14px;
+      border: 2px solid rgba(255, 255, 255, 0.06);
+      border-top-color: #818cf8;
       border-radius: 50%;
       animation: spin 0.7s linear infinite;
       flex-shrink: 0;
@@ -75,41 +78,41 @@
     #results {
       overflow-y: auto;
       flex: 1;
-      padding: 6px 0;
+      padding: 4px;
     }
 
     #results::-webkit-scrollbar { width: 4px; }
     #results::-webkit-scrollbar-track { background: transparent; }
-    #results::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.12); border-radius: 2px; }
+    #results::-webkit-scrollbar-thumb { background: #6b7280; border-radius: 2px; opacity: 0.3; }
 
     .result-item {
       display: flex;
       flex-direction: column;
-      padding: 10px 18px;
+      padding: 8px 12px;
       cursor: pointer;
-      gap: 3px;
-      transition: background 0.1s;
-      border-left: 3px solid transparent;
+      gap: 2px;
+      transition: background 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+      border-radius: 8px;
+      margin: 1px 0;
     }
 
     .result-item.active,
     .result-item:hover {
-      background: rgba(96, 165, 250, 0.12);
-      border-left-color: #60a5fa;
+      background: rgba(129, 140, 248, 0.12);
     }
 
     .result-title {
-      font-size: 0.9rem;
+      font-size: 0.85rem;
       font-weight: 500;
-      color: rgba(255,255,255,0.9);
+      color: #f3f4f6;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
     }
 
     .result-snippet {
-      font-size: 0.77rem;
-      color: rgba(255,255,255,0.38);
+      font-size: 0.75rem;
+      color: #9ca3af;
       line-height: 1.4;
       display: -webkit-box;
       -webkit-line-clamp: 2;
@@ -120,13 +123,24 @@
     .result-meta {
       display: flex;
       align-items: center;
-      gap: 10px;
-      margin-top: 1px;
+      gap: 8px;
+      margin-top: 2px;
+    }
+
+    .result-type {
+      font-size: 0.65rem;
+      padding: 1px 5px;
+      border-radius: 3px;
+      background: #22222f;
+      color: #9ca3af;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      flex-shrink: 0;
     }
 
     .result-path {
-      font-size: 0.7rem;
-      color: rgba(255,255,255,0.22);
+      font-size: 0.68rem;
+      color: #6b7280;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -134,47 +148,37 @@
     }
 
     .result-score {
-      font-size: 0.68rem;
-      color: rgba(96,165,250,0.6);
+      font-size: 0.65rem;
+      color: #818cf8;
       flex-shrink: 0;
       font-variant-numeric: tabular-nums;
-    }
-
-    .result-type {
-      font-size: 0.66rem;
-      padding: 1px 5px;
-      border-radius: 3px;
-      background: rgba(255,255,255,0.07);
-      color: rgba(255,255,255,0.35);
-      flex-shrink: 0;
-      text-transform: uppercase;
-      letter-spacing: 0.04em;
+      opacity: 0.7;
     }
 
     .empty {
-      padding: 28px 20px;
+      padding: 24px 16px;
       text-align: center;
-      color: rgba(255,255,255,0.22);
-      font-size: 0.88rem;
+      color: #6b7280;
+      font-size: 0.85rem;
     }
 
     /* ── Hint bar ───────────────────────────────────────────────────────── */
     .hint-bar {
       display: flex;
       justify-content: space-between;
-      padding: 7px 18px;
-      font-size: 0.7rem;
-      color: rgba(255,255,255,0.18);
-      border-top: 1px solid rgba(255,255,255,0.05);
+      padding: 6px 16px;
+      font-size: 0.68rem;
+      color: #6b7280;
+      border-top: 1px solid rgba(255, 255, 255, 0.06);
       flex-shrink: 0;
     }
 
     kbd {
-      background: rgba(255,255,255,0.08);
+      background: #22222f;
       border-radius: 3px;
-      padding: 1px 5px;
+      padding: 1px 4px;
       font-family: inherit;
-      font-size: 0.68rem;
+      font-size: 0.65rem;
     }
   </style>
 </head>
@@ -182,7 +186,7 @@
   <div class="window">
     <div class="search-bar">
       <span class="search-icon">
-        <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+        <svg width="18" height="18" viewBox="0 0 20 20" fill="none">
           <circle cx="9" cy="9" r="5.5" stroke="currentColor" stroke-width="1.7"/>
           <path d="M13.5 13.5L17 17" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/>
         </svg>
@@ -190,7 +194,7 @@
       <input
         id="spotlight-input"
         type="text"
-        placeholder="Search your documents…"
+        placeholder="Search your documents… (min 3 chars)"
         autocomplete="off"
         spellcheck="false"
         autofocus
@@ -201,7 +205,7 @@
     <div id="results"></div>
 
     <div class="hint-bar">
-      <span><kbd>↑↓</kbd> navigate · <kbd>↵</kbd> open · <kbd>Esc</kbd> close</span>
+      <span><kbd>&uarr;&darr;</kbd> navigate &middot; <kbd>&crarr;</kbd> open &middot; <kbd>Esc</kbd> close</span>
       <span>DocFinder</span>
     </div>
   </div>
@@ -279,19 +283,17 @@
 
     function hideSpotlight() {
       if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.spotlight) {
-        // Native NSPanel via WKScriptMessageHandler
         window.webkit.messageHandlers.spotlight.postMessage({ action: 'hide' });
       } else if (window.pywebview) {
-        // pywebview fallback (non-macOS or legacy builds)
         window.pywebview.api.hide_spotlight();
       } else {
-        // HTTP fallback: native WKWebView (SpotlightPanel) without message handler
         fetch(apiBase + '/gui/spotlight/hide', { method: 'POST' }).catch(() => {});
       }
     }
 
     async function doSearch(query) {
-      if (!query.trim()) {
+      const trimmed = query.trim();
+      if (trimmed.length < 3) {
         results.innerHTML = '';
         currentResults = [];
         return;
@@ -301,13 +303,17 @@
         const res  = await fetch(`${apiBase}/search`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ query: query.trim(), top_k: 8 }),
+          body: JSON.stringify({ query: trimmed, top_k: 10 }),
         });
         const data = await res.json();
-        if (res.ok) renderResults(data.results || []);
-        else results.innerHTML = `<div class="empty">${escHtml(data.detail || 'Error')}</div>`;
+        if (res.ok) {
+          const relevant = (data.results || []).filter(r => r.score >= 0.3);
+          renderResults(relevant);
+        } else {
+          results.innerHTML = `<div class="empty">${escHtml(data.detail || 'Error')}</div>`;
+        }
       } catch (_) {
-        results.innerHTML = '<div class="empty">Search unavailable — is DocFinder indexed?</div>';
+        results.innerHTML = '<div class="empty">Search unavailable \u2014 is DocFinder indexed?</div>';
       } finally {
         spinner.classList.remove('active');
       }
@@ -316,7 +322,9 @@
     // Debounced search
     input.addEventListener('input', () => {
       clearTimeout(debounceTimer);
-      debounceTimer = setTimeout(() => doSearch(input.value), 300);
+      const q = input.value.trim();
+      if (q.length < 3) { results.innerHTML = ''; currentResults = []; return; }
+      debounceTimer = setTimeout(() => doSearch(input.value), 500);
     });
 
     // Keyboard navigation

--- a/src/docfinder/web/templates/spotlight.html
+++ b/src/docfinder/web/templates/spotlight.html
@@ -42,6 +42,7 @@
       border-bottom: 1px solid rgba(255, 255, 255, 0.06);
       flex-shrink: 0;
       -webkit-app-region: drag;
+      border-radius: 14px 14px 0 0;
     }
 
     #spotlight-input, .spinner-sm { -webkit-app-region: no-drag; }
@@ -50,14 +51,21 @@
 
     #spotlight-input {
       flex: 1;
-      background: none;
-      border: none;
+      background: rgba(129, 140, 248, 0.08);
+      border: 1px solid rgba(129, 140, 248, 0.18);
+      border-radius: 10px;
+      padding: 0.45rem 0.65rem;
       outline: none;
       font-size: 1.05rem;
       font-weight: 400;
       color: #f3f4f6;
       caret-color: #818cf8;
       font-family: inherit;
+    }
+
+    #spotlight-input:focus {
+      border-color: rgba(129, 140, 248, 0.45);
+      box-shadow: 0 0 0 2px rgba(129, 140, 248, 0.14);
     }
 
     #spotlight-input::placeholder { color: #6b7280; }
@@ -194,7 +202,7 @@
       <input
         id="spotlight-input"
         type="text"
-        placeholder="Search your documents… (min 3 chars)"
+        placeholder="Search your documents… (min 2 chars)"
         autocomplete="off"
         spellcheck="false"
         autofocus
@@ -293,7 +301,7 @@
 
     async function doSearch(query) {
       const trimmed = query.trim();
-      if (trimmed.length < 3) {
+      if (trimmed.length < 2) {
         results.innerHTML = '';
         currentResults = [];
         return;
@@ -307,8 +315,9 @@
         });
         const data = await res.json();
         if (res.ok) {
-          const relevant = (data.results || []).filter(r => r.score >= 0.3);
-          renderResults(relevant);
+          const scored = data.results || [];
+          const relevant = scored.filter(r => r.score >= 0.2);
+          renderResults(relevant.length ? relevant : scored);
         } else {
           results.innerHTML = `<div class="empty">${escHtml(data.detail || 'Error')}</div>`;
         }
@@ -323,7 +332,7 @@
     input.addEventListener('input', () => {
       clearTimeout(debounceTimer);
       const q = input.value.trim();
-      if (q.length < 3) { results.innerHTML = ''; currentResults = []; return; }
+      if (q.length < 2) { results.innerHTML = ''; currentResults = []; return; }
       debounceTimer = setTimeout(() => doSearch(input.value), 500);
     });
 

--- a/tests/test_embedding_backend.py
+++ b/tests/test_embedding_backend.py
@@ -15,6 +15,7 @@ from docfinder.embedding.encoder import (
     _check_gpu_availability,
     _check_onnx_providers,
     detect_optimal_backend,
+    detect_optimal_backend_config,
 )
 
 
@@ -148,6 +149,24 @@ class TestBackendDetection:
         backend, model_file = detect_optimal_backend()
         assert backend == "onnx"
         assert model_file is None
+
+    @patch("docfinder.embedding.encoder._check_gpu_availability", return_value=(True, "cuda"))
+    @patch(
+        "docfinder.embedding.encoder._check_onnx_providers",
+        return_value=["CPUExecutionProvider"],
+    )
+    def test_detect_cuda_without_onnx_cuda_provider_uses_torch_cuda(
+        self,
+        mock_onnx_providers: MagicMock,
+        mock_gpu_check: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Should use torch/cuda if GPU exists but ONNX CUDA provider is missing."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        backend, model_file, device = detect_optimal_backend_config()
+        assert backend == "torch"
+        assert model_file is None
+        assert device == "cuda"
 
 
 class TestEmbeddingConfig:

--- a/tests/test_embedding_backend.py
+++ b/tests/test_embedding_backend.py
@@ -14,6 +14,7 @@ from docfinder.embedding.encoder import (
     EmbeddingModel,
     _check_gpu_availability,
     _check_onnx_providers,
+    _preferred_torch_device,
     detect_optimal_backend,
     detect_optimal_backend_config,
 )
@@ -55,6 +56,11 @@ class TestGPUDetection:
         assert isinstance(providers, list)
         # On macOS we should have at least CPU provider
         assert "CPUExecutionProvider" in providers
+
+    @patch("docfinder.embedding.encoder._check_gpu_availability", return_value=(True, "mps"))
+    def test_preferred_torch_device_mps(self, mock_gpu_check: MagicMock) -> None:
+        """Should prefer mps torch device when MPS is available."""
+        assert _preferred_torch_device() == "mps"
 
 
 class TestBackendDetection:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 import numpy as np
 import pytest
 
-from docfinder.index.indexer import Indexer, IndexStats
+from docfinder.index.indexer import Indexer, IndexStats, _parse_document
 from docfinder.models import ChunkRecord
 
 
@@ -399,3 +399,292 @@ class TestIndexer:
         document = call_args[0][0]
         assert document.mtime == pdf_path.stat().st_mtime
         assert document.size == pdf_path.stat().st_size
+
+
+class TestParseDocument:
+    """Test the module-level _parse_document function."""
+
+    @patch("docfinder.index.indexer.compute_sha256")
+    @patch("docfinder.index.indexer.build_chunks")
+    def test_parse_document_success(self, mock_build_chunks, mock_sha256, tmp_path):
+        """Test successful document parsing."""
+        pdf_path = tmp_path / "test.pdf"
+        pdf_path.write_text("test content")
+        mock_sha256.return_value = "abc123"
+        mock_build_chunks.return_value = [
+            ChunkRecord(document_path=pdf_path, index=0, text="Chunk 1", metadata={"title": "T"}),
+            ChunkRecord(document_path=pdf_path, index=1, text="Chunk 2", metadata={}),
+        ]
+
+        result = _parse_document((str(pdf_path), 1200, 200))
+
+        assert result["status"] == "ok"
+        assert result["path"] == str(pdf_path)
+        assert result["sha256"] == "abc123"
+        assert result["title"] == "T"
+        assert len(result["chunks"]) == 2
+        assert result["chunks"][0]["text"] == "Chunk 1"
+        assert result["chunks"][1]["index"] == 1
+
+    @patch("docfinder.index.indexer.build_chunks")
+    def test_parse_document_empty(self, mock_build_chunks, tmp_path):
+        """Test parsing a document with no extractable text."""
+        pdf_path = tmp_path / "empty.pdf"
+        pdf_path.write_text("empty")
+        mock_build_chunks.return_value = []
+
+        result = _parse_document((str(pdf_path), 1200, 200))
+
+        assert result["status"] == "empty"
+        assert result["path"] == str(pdf_path)
+
+    @patch("docfinder.index.indexer.build_chunks")
+    def test_parse_document_error(self, mock_build_chunks, tmp_path):
+        """Test parsing a document that raises an exception."""
+        pdf_path = tmp_path / "broken.pdf"
+        pdf_path.write_text("broken")
+        mock_build_chunks.side_effect = Exception("Parse error")
+
+        result = _parse_document((str(pdf_path), 1200, 200))
+
+        assert result["status"] == "error"
+        assert result["path"] == str(pdf_path)
+        assert "Parse error" in result["error"]
+
+
+class TestParallelIndexing:
+    """Test parallel indexing path."""
+
+    @pytest.fixture
+    def mock_embedder(self):
+        """Create mock EmbeddingModel."""
+        embedder = Mock()
+        embedder.embed.return_value = np.random.rand(2, 384).astype("float32")
+        return embedder
+
+    @pytest.fixture
+    def mock_store(self):
+        """Create mock SQLiteVectorStore."""
+        store = Mock()
+        store.init_document.return_value = (1, "inserted")
+        store.insert_chunks.return_value = None
+        store.transaction.return_value.__enter__ = Mock()
+        store.transaction.return_value.__exit__ = Mock()
+        return store
+
+    def test_should_parallelize_true_by_default(self, mock_embedder, mock_store):
+        """Test that _should_parallelize returns True when no fixed batch size."""
+        indexer = Indexer(mock_embedder, mock_store)
+        assert indexer._should_parallelize() is True
+
+    def test_should_parallelize_false_with_fixed_batch(self, mock_embedder, mock_store):
+        """Test that _should_parallelize returns False with fixed embed_batch_size."""
+        indexer = Indexer(mock_embedder, mock_store, embed_batch_size=32)
+        assert indexer._should_parallelize() is False
+
+    @patch("docfinder.index.indexer.iter_document_paths")
+    def test_sequential_path_used_for_few_files(
+        self, mock_iter_pdfs, mock_embedder, mock_store, tmp_path
+    ):
+        """Test that sequential path is used when < 4 files."""
+        files = []
+        for i in range(3):
+            p = tmp_path / f"doc{i}.pdf"
+            p.write_text(f"test{i}")
+            files.append(p)
+        mock_iter_pdfs.return_value = files
+
+        indexer = Indexer(mock_embedder, mock_store)
+
+        with (
+            patch.object(indexer, "_index_sequential") as mock_seq,
+            patch.object(indexer, "_index_parallel") as mock_par,
+        ):
+            indexer.index([tmp_path])
+            mock_seq.assert_called_once()
+            mock_par.assert_not_called()
+
+    @patch("docfinder.index.indexer.iter_document_paths")
+    def test_parallel_path_used_for_many_files(
+        self, mock_iter_pdfs, mock_embedder, mock_store, tmp_path
+    ):
+        """Test that parallel path is used when >= 4 files."""
+        files = []
+        for i in range(4):
+            p = tmp_path / f"doc{i}.pdf"
+            p.write_text(f"test{i}")
+            files.append(p)
+        mock_iter_pdfs.return_value = files
+
+        indexer = Indexer(mock_embedder, mock_store)
+
+        with (
+            patch.object(indexer, "_index_sequential") as mock_seq,
+            patch.object(indexer, "_index_parallel") as mock_par,
+        ):
+            indexer.index([tmp_path])
+            mock_par.assert_called_once()
+            mock_seq.assert_not_called()
+
+    @patch("docfinder.index.indexer.iter_document_paths")
+    def test_sequential_path_when_batch_size_set(
+        self, mock_iter_pdfs, mock_embedder, mock_store, tmp_path
+    ):
+        """Test that sequential path is used when embed_batch_size is set, even with many files."""
+        files = []
+        for i in range(5):
+            p = tmp_path / f"doc{i}.pdf"
+            p.write_text(f"test{i}")
+            files.append(p)
+        mock_iter_pdfs.return_value = files
+
+        indexer = Indexer(mock_embedder, mock_store, embed_batch_size=32)
+
+        with (
+            patch.object(indexer, "_index_sequential") as mock_seq,
+            patch.object(indexer, "_index_parallel") as mock_par,
+        ):
+            indexer.index([tmp_path])
+            mock_seq.assert_called_once()
+            mock_par.assert_not_called()
+
+    @patch("docfinder.index.indexer.ProcessPoolExecutor")
+    @patch("docfinder.index.indexer.iter_document_paths")
+    def test_parallel_indexing_with_mocked_executor(
+        self, mock_iter_pdfs, mock_executor_cls, mock_embedder, mock_store, tmp_path
+    ):
+        """Test parallel indexing end-to-end with mocked ProcessPoolExecutor."""
+        files = []
+        for i in range(4):
+            p = tmp_path / f"doc{i}.pdf"
+            p.write_text(f"test{i}")
+            files.append(p)
+        mock_iter_pdfs.return_value = files
+
+        # Simulate parsed results from worker processes
+        parsed_results = [
+            {
+                "path": str(files[0]),
+                "status": "ok",
+                "sha256": "h0",
+                "mtime": 1000.0,
+                "size": 100,
+                "title": "Doc 0",
+                "chunks": [{"index": 0, "text": "text0", "metadata": {"title": "Doc 0"}}],
+            },
+            {
+                "path": str(files[1]),
+                "status": "ok",
+                "sha256": "h1",
+                "mtime": 1001.0,
+                "size": 101,
+                "title": "Doc 1",
+                "chunks": [{"index": 0, "text": "text1", "metadata": {"title": "Doc 1"}}],
+            },
+            {"path": str(files[2]), "status": "empty"},
+            {"path": str(files[3]), "status": "error", "error": "bad pdf"},
+        ]
+
+        mock_executor = Mock()
+        mock_executor.__enter__ = Mock(return_value=mock_executor)
+        mock_executor.__exit__ = Mock(return_value=False)
+        mock_executor.map.return_value = parsed_results
+        mock_executor_cls.return_value = mock_executor
+
+        mock_store.init_document.side_effect = [(1, "inserted"), (2, "inserted")]
+
+        indexer = Indexer(mock_embedder, mock_store)
+        stats = indexer.index([tmp_path])
+
+        assert stats.inserted == 2
+        assert stats.skipped == 1
+        assert stats.failed == 1
+        assert len(stats.processed_files) == 4
+        assert mock_embedder.embed.call_count == 2
+        assert mock_store.insert_chunks.call_count == 2
+
+    @patch("docfinder.index.indexer.ProcessPoolExecutor")
+    @patch("docfinder.index.indexer.iter_document_paths")
+    def test_parallel_progress_callback(
+        self, mock_iter_pdfs, mock_executor_cls, mock_embedder, mock_store, tmp_path
+    ):
+        """Test that progress callback fires during parallel indexing."""
+        files = []
+        for i in range(4):
+            p = tmp_path / f"doc{i}.pdf"
+            p.write_text(f"test{i}")
+            files.append(p)
+        mock_iter_pdfs.return_value = files
+
+        parsed_results = [
+            {
+                "path": str(f),
+                "status": "ok",
+                "sha256": f"h{i}",
+                "mtime": 1000.0,
+                "size": 100,
+                "title": f"Doc {i}",
+                "chunks": [{"index": 0, "text": f"text{i}", "metadata": {}}],
+            }
+            for i, f in enumerate(files)
+        ]
+
+        mock_executor = Mock()
+        mock_executor.__enter__ = Mock(return_value=mock_executor)
+        mock_executor.__exit__ = Mock(return_value=False)
+        mock_executor.map.return_value = parsed_results
+        mock_executor_cls.return_value = mock_executor
+
+        mock_store.init_document.side_effect = [(i, "inserted") for i in range(1, 5)]
+
+        callback = Mock()
+        indexer = Indexer(mock_embedder, mock_store, progress_callback=callback)
+        indexer.index([tmp_path])
+
+        # 4 per-file calls + 1 final completion call
+        assert callback.call_count == 5
+        # Final call should be (total, total, "")
+        callback.assert_any_call(4, 4, "")
+
+    @patch("docfinder.index.indexer.ProcessPoolExecutor")
+    @patch("docfinder.index.indexer.iter_document_paths")
+    def test_parallel_skipped_by_store(
+        self, mock_iter_pdfs, mock_executor_cls, mock_embedder, mock_store, tmp_path
+    ):
+        """Test that store-level skip works in parallel path."""
+        files = []
+        for i in range(4):
+            p = tmp_path / f"doc{i}.pdf"
+            p.write_text(f"test{i}")
+            files.append(p)
+        mock_iter_pdfs.return_value = files
+
+        parsed_results = [
+            {
+                "path": str(f),
+                "status": "ok",
+                "sha256": f"h{i}",
+                "mtime": 1000.0,
+                "size": 100,
+                "title": f"Doc {i}",
+                "chunks": [{"index": 0, "text": f"text{i}", "metadata": {}}],
+            }
+            for i, f in enumerate(files)
+        ]
+
+        mock_executor = Mock()
+        mock_executor.__enter__ = Mock(return_value=mock_executor)
+        mock_executor.__exit__ = Mock(return_value=False)
+        mock_executor.map.return_value = parsed_results
+        mock_executor_cls.return_value = mock_executor
+
+        # All documents already indexed (skipped)
+        mock_store.init_document.return_value = (-1, "skipped")
+
+        indexer = Indexer(mock_embedder, mock_store)
+        stats = indexer.index([tmp_path])
+
+        assert stats.skipped == 4
+        assert stats.inserted == 0
+        mock_embedder.embed.assert_not_called()
+        mock_store.insert_chunks.assert_not_called()

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -688,3 +688,23 @@ class TestParallelIndexing:
         assert stats.inserted == 0
         mock_embedder.embed.assert_not_called()
         mock_store.insert_chunks.assert_not_called()
+
+    @patch("docfinder.index.indexer.get_memory_info", return_value={"available_mb": 16000})
+    def test_compute_parallel_workers_balanced_caps_high_mem(
+        self, mock_mem_info, mock_embedder, mock_store
+    ):
+        """Should keep one CPU free and cap balanced workers."""
+        indexer = Indexer(mock_embedder, mock_store)
+        with patch("os.cpu_count", return_value=12):
+            workers = indexer._compute_parallel_workers(20)
+        assert workers == 8
+
+    @patch("docfinder.index.indexer.get_memory_info", return_value={"available_mb": 1500})
+    def test_compute_parallel_workers_balanced_low_mem(
+        self, mock_mem_info, mock_embedder, mock_store
+    ):
+        """Should reduce worker count on low-memory hosts."""
+        indexer = Indexer(mock_embedder, mock_store)
+        with patch("os.cpu_count", return_value=8):
+            workers = indexer._compute_parallel_workers(10)
+        assert workers == 2

--- a/tests/test_pdf_loader.py
+++ b/tests/test_pdf_loader.py
@@ -608,13 +608,10 @@ class TestIterTextPartsDocx:
     def test_extracts_paragraphs(self, tmp_path: Path) -> None:
         from docfinder.ingestion.pdf_loader import iter_text_parts_docx
 
-        try:
-            from docx import Document
-        except ImportError:
-            pytest.skip("python-docx not installed")
+        docx = pytest.importorskip("docx")
 
         f = tmp_path / "test.docx"
-        doc = Document()
+        doc = docx.Document()
         doc.add_paragraph("First paragraph")
         doc.add_paragraph("")  # empty — should be skipped
         doc.add_paragraph("Second paragraph")
@@ -628,10 +625,7 @@ class TestIterTextPartsDocx:
     def test_read_error(self, tmp_path: Path) -> None:
         from docfinder.ingestion.pdf_loader import iter_text_parts_docx
 
-        try:
-            from docx import Document  # noqa: F401
-        except ImportError:
-            pytest.skip("python-docx not installed")
+        pytest.importorskip("docx")
 
         f = tmp_path / "corrupt.docx"
         f.write_bytes(b"not a real docx")
@@ -645,10 +639,7 @@ class TestIterTextPartsDocxPaged:
     def test_read_error(self, tmp_path: Path) -> None:
         from docfinder.ingestion.pdf_loader import iter_text_parts_docx_paged
 
-        try:
-            from docx import Document  # noqa: F401
-        except ImportError:
-            pytest.skip("python-docx not installed")
+        pytest.importorskip("docx")
 
         f = tmp_path / "corrupt.docx"
         f.write_bytes(b"not a real docx")
@@ -658,13 +649,10 @@ class TestIterTextPartsDocxPaged:
     def test_fewer_than_page_size(self, tmp_path: Path) -> None:
         from docfinder.ingestion.pdf_loader import iter_text_parts_docx_paged
 
-        try:
-            from docx import Document
-        except ImportError:
-            pytest.skip("python-docx not installed")
+        docx = pytest.importorskip("docx")
 
         f = tmp_path / "small.docx"
-        doc = Document()
+        doc = docx.Document()
         for i in range(3):
             doc.add_paragraph(f"Para {i}")
         doc.save(str(f))
@@ -680,13 +668,10 @@ class TestImportDocxDocument:
     def test_returns_document_class(self) -> None:
         from docfinder.ingestion.pdf_loader import _import_docx_document
 
-        try:
-            from docx import Document
-        except ImportError:
-            pytest.skip("python-docx not installed")
+        docx = pytest.importorskip("docx")
 
         result = _import_docx_document()
-        assert result is Document
+        assert result is docx.Document
 
     @patch.dict("sys.modules", {"docx": None})
     def test_returns_none_when_not_installed(self) -> None:
@@ -727,13 +712,10 @@ class TestIterTextBySuffix:
     def test_docx_dispatch(self, tmp_path: Path) -> None:
         from docfinder.ingestion.pdf_loader import _iter_text_by_suffix
 
-        try:
-            from docx import Document
-        except ImportError:
-            pytest.skip("python-docx not installed")
+        docx = pytest.importorskip("docx")
 
         f = tmp_path / "file.docx"
-        doc = Document()
+        doc = docx.Document()
         doc.add_paragraph("docx content")
         doc.save(str(f))
         parts = list(_iter_text_by_suffix(f))
@@ -804,13 +786,10 @@ class TestIterPagedText:
     def test_dispatches_docx(self, tmp_path: Path) -> None:
         from docfinder.ingestion.pdf_loader import _iter_paged_text
 
-        try:
-            from docx import Document
-        except ImportError:
-            pytest.skip("python-docx not installed")
+        docx = pytest.importorskip("docx")
 
         f = tmp_path / "file.docx"
-        doc = Document()
+        doc = docx.Document()
         doc.add_paragraph("Hello")
         doc.save(str(f))
         pages = list(_iter_paged_text(f))

--- a/tests/test_pdf_loader.py
+++ b/tests/test_pdf_loader.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from docfinder.ingestion.pdf_loader import build_chunks, get_pdf_metadata, iter_text_parts
 from docfinder.models import ChunkRecord
 
@@ -18,6 +20,7 @@ class TestIterTextParts:
         # Setup mock
         mock_page = MagicMock()
         mock_page.get_text.return_value = "Page 1 text"
+        mock_page.find_tables.return_value = MagicMock(tables=[])
 
         mock_doc = MagicMock()
         mock_doc.__len__ = MagicMock(return_value=1)
@@ -40,10 +43,13 @@ class TestIterTextParts:
         # Setup mock pages
         mock_page1 = MagicMock()
         mock_page1.get_text.return_value = "Page 1"
+        mock_page1.find_tables.return_value = MagicMock(tables=[])
         mock_page2 = MagicMock()
         mock_page2.get_text.return_value = "Page 2"
+        mock_page2.find_tables.return_value = MagicMock(tables=[])
         mock_page3 = MagicMock()
         mock_page3.get_text.return_value = "Page 3"
+        mock_page3.find_tables.return_value = MagicMock(tables=[])
 
         pages = [mock_page1, mock_page2, mock_page3]
 
@@ -71,12 +77,15 @@ class TestIterTextParts:
         """Should log warning and continue on page extraction error."""
         mock_page1 = MagicMock()
         mock_page1.get_text.return_value = "Page 1"
+        mock_page1.find_tables.return_value = MagicMock(tables=[])
 
         mock_page2 = MagicMock()
+        mock_page2.find_tables.return_value = MagicMock(tables=[])
         mock_page2.get_text.side_effect = Exception("Extraction failed")
 
         mock_page3 = MagicMock()
         mock_page3.get_text.return_value = "Page 3"
+        mock_page3.find_tables.return_value = MagicMock(tables=[])
 
         pages = [mock_page1, mock_page2, mock_page3]
 
@@ -199,7 +208,8 @@ class TestBuildChunks:
         self, mock_meta: MagicMock, mock_iter: MagicMock, tmp_path: Path
     ) -> None:
         """Should create multiple chunks for long text."""
-        long_text = "x" * 500
+        # Use text with sentence boundaries so the sentence-aware chunker can split it
+        long_text = " ".join(f"Sentence number {i} is here." for i in range(50))
         mock_meta.return_value = {"title": "Long", "page_count": "1"}
         mock_iter.return_value = iter([(1, long_text)])
 
@@ -248,3 +258,622 @@ class TestBuildChunks:
 
         # Should return no chunks for empty text
         assert len(chunks) == 0
+
+
+class TestTableExtraction:
+    """Test PDF table extraction via _extract_page_text."""
+
+    def test_table_to_markdown(self) -> None:
+        """Should convert a table to Markdown format."""
+        from docfinder.ingestion.pdf_loader import _table_to_markdown
+
+        mock_table = MagicMock()
+        mock_table.extract.return_value = [
+            ["Name", "Age", "City"],
+            ["Marco", "30", "Roma"],
+            ["Laura", "25", "Milano"],
+        ]
+        md = _table_to_markdown(mock_table)
+        assert "| Name | Age | City |" in md
+        assert "| --- | --- | --- |" in md
+        assert "| Marco | 30 | Roma |" in md
+        assert "| Laura | 25 | Milano |" in md
+
+    def test_table_to_markdown_empty(self) -> None:
+        """Should return empty string for empty table."""
+        from docfinder.ingestion.pdf_loader import _table_to_markdown
+
+        mock_table = MagicMock()
+        mock_table.extract.return_value = []
+        assert _table_to_markdown(mock_table) == ""
+
+    def test_table_to_markdown_none_cells(self) -> None:
+        """Should handle None cell values gracefully."""
+        from docfinder.ingestion.pdf_loader import _table_to_markdown
+
+        mock_table = MagicMock()
+        mock_table.extract.return_value = [
+            ["Col1", None],
+            [None, "value"],
+        ]
+        md = _table_to_markdown(mock_table)
+        assert "| Col1 |  |" in md
+        assert "|  | value |" in md
+
+    @patch("docfinder.ingestion.pdf_loader.fitz")
+    def test_extract_page_with_table(self, mock_fitz: MagicMock) -> None:
+        """Should include Markdown table in extracted text."""
+        from docfinder.ingestion.pdf_loader import _extract_page_text
+
+        # Mock a table
+        mock_table = MagicMock()
+        mock_table.bbox = (0, 100, 500, 200)
+        mock_table.extract.return_value = [
+            ["Product", "Price"],
+            ["Widget", "10.00"],
+        ]
+
+        mock_tables_result = MagicMock()
+        mock_tables_result.tables = [mock_table]
+
+        # Mock fitz.Rect to return proper rect objects
+        mock_fitz.Rect.side_effect = lambda coords: MagicMock(
+            y0=coords[1],
+            width=coords[2] - coords[0],
+            height=coords[3] - coords[1],
+            is_empty=False,
+            __and__=lambda self, other: MagicMock(
+                is_empty=False, width=self.width, height=self.height
+            ),
+        )
+
+        mock_page = MagicMock()
+        mock_page.find_tables.return_value = mock_tables_result
+        # Text blocks outside the table area
+        mock_page.get_text.return_value = [
+            (0, 10, 500, 50, "Introduction paragraph.", 0, 0),
+        ]
+
+        text = _extract_page_text(mock_page)
+        assert "Product" in text
+        assert "Price" in text
+        assert "Widget" in text
+
+    @patch("docfinder.ingestion.pdf_loader.fitz")
+    def test_extract_page_no_tables(self, mock_fitz: MagicMock) -> None:
+        """Should fall back to plain text when no tables found."""
+        from docfinder.ingestion.pdf_loader import _extract_page_text
+
+        mock_page = MagicMock()
+        mock_page.find_tables.return_value = MagicMock(tables=[])
+        mock_page.get_text.return_value = "Just plain text here."
+
+        text = _extract_page_text(mock_page)
+        assert text == "Just plain text here."
+
+    def test_extract_page_find_tables_exception(self) -> None:
+        """Should fall back to plain text when find_tables() raises."""
+        from docfinder.ingestion.pdf_loader import _extract_page_text
+
+        mock_page = MagicMock()
+        mock_page.find_tables.side_effect = RuntimeError("unsupported")
+        mock_page.get_text.return_value = "Fallback text."
+
+        text = _extract_page_text(mock_page)
+        assert text == "Fallback text."
+
+    @patch("docfinder.ingestion.pdf_loader.fitz")
+    def test_extract_page_skips_image_blocks(self, mock_fitz: MagicMock) -> None:
+        """Should skip image blocks (block_type != 0)."""
+        from docfinder.ingestion.pdf_loader import _extract_page_text
+
+        mock_table = MagicMock()
+        mock_table.bbox = (0, 200, 500, 300)
+        mock_table.extract.return_value = [["A"], ["1"]]
+
+        mock_tables_result = MagicMock()
+        mock_tables_result.tables = [mock_table]
+
+        mock_fitz.Rect.side_effect = lambda coords: MagicMock(
+            y0=coords[1],
+            width=coords[2] - coords[0],
+            height=coords[3] - coords[1],
+            is_empty=False,
+            __and__=lambda self, other: MagicMock(is_empty=True),
+        )
+
+        mock_page = MagicMock()
+        mock_page.find_tables.return_value = mock_tables_result
+        mock_page.get_text.return_value = [
+            (0, 10, 500, 50, "Text block.", 0, 0),  # text block — kept
+            (0, 60, 500, 100, "image data", 1, 1),  # image block — skipped
+        ]
+
+        text = _extract_page_text(mock_page)
+        assert "Text block." in text
+        assert "image data" not in text
+
+    @patch("docfinder.ingestion.pdf_loader.fitz")
+    def test_extract_page_excludes_overlapping_text(self, mock_fitz: MagicMock) -> None:
+        """Text blocks overlapping >50% with a table should be excluded."""
+        from docfinder.ingestion.pdf_loader import _extract_page_text
+
+        mock_table = MagicMock()
+        mock_table.bbox = (0, 100, 500, 200)
+        mock_table.extract.return_value = [["Col"], ["Val"]]
+
+        mock_tables_result = MagicMock()
+        mock_tables_result.tables = [mock_table]
+
+        # Table rect
+        table_rect = MagicMock(
+            y0=100,
+            width=500,
+            height=100,
+            is_empty=False,
+        )
+        # Block inside table: full overlap
+        block_inside_rect = MagicMock(
+            y0=110,
+            width=500,
+            height=30,
+            is_empty=False,
+        )
+        # Block outside table: no overlap
+        block_outside_rect = MagicMock(
+            y0=10,
+            width=500,
+            height=40,
+            is_empty=False,
+        )
+
+        rects = [table_rect, block_outside_rect, block_inside_rect]
+        mock_fitz.Rect.side_effect = rects
+
+        # Overlap intersection for inside block: full overlap → ratio = 1.0
+        full_overlap = MagicMock(is_empty=False, width=500, height=30)
+        block_inside_rect.__and__ = MagicMock(return_value=full_overlap)
+        # No overlap for outside block
+        no_overlap = MagicMock(is_empty=True)
+        block_outside_rect.__and__ = MagicMock(return_value=no_overlap)
+
+        mock_page = MagicMock()
+        mock_page.find_tables.return_value = mock_tables_result
+        mock_page.get_text.return_value = [
+            (0, 10, 500, 50, "Outside text.", 0, 0),
+            (0, 110, 500, 140, "Inside table text.", 1, 0),
+        ]
+
+        text = _extract_page_text(mock_page)
+        assert "Outside text." in text
+        assert "Inside table text." not in text
+
+    def test_table_to_markdown_newlines_in_cells(self) -> None:
+        """Should replace newlines in cell values with spaces."""
+        from docfinder.ingestion.pdf_loader import _table_to_markdown
+
+        mock_table = MagicMock()
+        mock_table.extract.return_value = [
+            ["Header"],
+            ["line1\nline2\nline3"],
+        ]
+        md = _table_to_markdown(mock_table)
+        assert "line1 line2 line3" in md
+        assert "\n" not in md.split("\n")[2]  # data row has no embedded newlines
+
+    def test_table_to_markdown_header_only(self) -> None:
+        """Should handle a table with only a header row."""
+        from docfinder.ingestion.pdf_loader import _table_to_markdown
+
+        mock_table = MagicMock()
+        mock_table.extract.return_value = [
+            ["Col1", "Col2"],
+        ]
+        md = _table_to_markdown(mock_table)
+        assert "| Col1 | Col2 |" in md
+        assert "| --- | --- |" in md
+        # Only 2 lines: header + separator
+        assert len(md.strip().split("\n")) == 2
+
+
+class TestIterTextPartsTxt:
+    """Test plain text extraction."""
+
+    def test_reads_text_file(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import iter_text_parts_txt
+
+        f = tmp_path / "hello.txt"
+        f.write_text("Hello world!", encoding="utf-8")
+        parts = list(iter_text_parts_txt(f))
+        assert len(parts) == 1
+        assert "Hello world!" in parts[0]
+
+    def test_read_error(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import iter_text_parts_txt
+
+        f = tmp_path / "missing.txt"
+        parts = list(iter_text_parts_txt(f))
+        assert parts == []
+
+
+class TestIterTextPartsTxtPaged:
+    """Test plain text virtual paging — error path."""
+
+    def test_read_error(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import iter_text_parts_txt_paged
+
+        f = tmp_path / "missing.txt"
+        pages = list(iter_text_parts_txt_paged(f))
+        assert pages == []
+
+    def test_whitespace_only_file(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import iter_text_parts_txt_paged
+
+        f = tmp_path / "blank.txt"
+        f.write_text("   \n\n  \n")
+        pages = list(iter_text_parts_txt_paged(f))
+        assert pages == []
+
+
+class TestCleanMd:
+    """Test Markdown formatting cleanup."""
+
+    def test_strips_bold_italic(self) -> None:
+        from docfinder.ingestion.pdf_loader import _clean_md
+
+        assert "hello" in _clean_md("**hello**")
+        assert "world" in _clean_md("*world*")
+        assert "***" not in _clean_md("***bold italic***")
+
+    def test_strips_links_keeps_text(self) -> None:
+        from docfinder.ingestion.pdf_loader import _clean_md
+
+        result = _clean_md("[click here](http://example.com)")
+        assert "click here" in result
+        assert "http://" not in result
+
+    def test_strips_images(self) -> None:
+        from docfinder.ingestion.pdf_loader import _clean_md
+
+        result = _clean_md("![alt text](image.png)")
+        assert "![" not in result
+        assert "image.png" not in result
+
+    def test_strips_code(self) -> None:
+        from docfinder.ingestion.pdf_loader import _clean_md
+
+        result = _clean_md("Use `print()` here")
+        assert "`" not in result
+
+    def test_strips_headings(self) -> None:
+        from docfinder.ingestion.pdf_loader import _clean_md
+
+        result = _clean_md("## My Title\nSome text")
+        assert "##" not in result
+        assert "My Title" in result
+
+    def test_strips_horizontal_rule(self) -> None:
+        from docfinder.ingestion.pdf_loader import _clean_md
+
+        result = _clean_md("Above\n---\nBelow")
+        assert "---" not in result
+        assert "Above" in result
+        assert "Below" in result
+
+
+class TestIterTextPartsMd:
+    """Test Markdown text extraction."""
+
+    def test_extracts_cleaned_text(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import iter_text_parts_md
+
+        f = tmp_path / "doc.md"
+        f.write_text("# Title\nSome **bold** text.")
+        parts = list(iter_text_parts_md(f))
+        assert len(parts) == 1
+        assert "bold" in parts[0]
+        assert "**" not in parts[0]
+
+    def test_read_error(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import iter_text_parts_md
+
+        f = tmp_path / "missing.md"
+        parts = list(iter_text_parts_md(f))
+        assert parts == []
+
+
+class TestIterTextPartsMdPaged:
+    """Test Markdown paged extraction — error path."""
+
+    def test_read_error(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import iter_text_parts_md_paged
+
+        f = tmp_path / "missing.md"
+        pages = list(iter_text_parts_md_paged(f))
+        assert pages == []
+
+    def test_empty_sections_skipped(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import iter_text_parts_md_paged
+
+        f = tmp_path / "sparse.md"
+        f.write_text("# Title\n\n\n# Another\nContent here.")
+        pages = list(iter_text_parts_md_paged(f))
+        # Only sections with actual content after cleaning
+        assert all(text.strip() for _, text in pages)
+
+
+class TestIterTextPartsDocx:
+    """Test Word document extraction."""
+
+    def test_extracts_paragraphs(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import iter_text_parts_docx
+
+        try:
+            from docx import Document
+        except ImportError:
+            pytest.skip("python-docx not installed")
+
+        f = tmp_path / "test.docx"
+        doc = Document()
+        doc.add_paragraph("First paragraph")
+        doc.add_paragraph("")  # empty — should be skipped
+        doc.add_paragraph("Second paragraph")
+        doc.save(str(f))
+
+        parts = list(iter_text_parts_docx(f))
+        assert len(parts) == 2
+        assert "First paragraph" in parts[0]
+        assert "Second paragraph" in parts[1]
+
+    def test_read_error(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import iter_text_parts_docx
+
+        try:
+            from docx import Document  # noqa: F401
+        except ImportError:
+            pytest.skip("python-docx not installed")
+
+        f = tmp_path / "corrupt.docx"
+        f.write_bytes(b"not a real docx")
+        parts = list(iter_text_parts_docx(f))
+        assert parts == []
+
+
+class TestIterTextPartsDocxPaged:
+    """Test Word document paged extraction — error and edge cases."""
+
+    def test_read_error(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import iter_text_parts_docx_paged
+
+        try:
+            from docx import Document  # noqa: F401
+        except ImportError:
+            pytest.skip("python-docx not installed")
+
+        f = tmp_path / "corrupt.docx"
+        f.write_bytes(b"not a real docx")
+        pages = list(iter_text_parts_docx_paged(f))
+        assert pages == []
+
+    def test_fewer_than_page_size(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import iter_text_parts_docx_paged
+
+        try:
+            from docx import Document
+        except ImportError:
+            pytest.skip("python-docx not installed")
+
+        f = tmp_path / "small.docx"
+        doc = Document()
+        for i in range(3):
+            doc.add_paragraph(f"Para {i}")
+        doc.save(str(f))
+
+        pages = list(iter_text_parts_docx_paged(f))
+        assert len(pages) == 1
+        assert pages[0][0] == 1
+
+
+class TestImportDocxDocument:
+    """Test python-docx lazy import."""
+
+    def test_returns_document_class(self) -> None:
+        from docfinder.ingestion.pdf_loader import _import_docx_document
+
+        try:
+            from docx import Document
+        except ImportError:
+            pytest.skip("python-docx not installed")
+
+        result = _import_docx_document()
+        assert result is Document
+
+    @patch.dict("sys.modules", {"docx": None})
+    def test_returns_none_when_not_installed(self) -> None:
+        from docfinder.ingestion.pdf_loader import _import_docx_document
+
+        result = _import_docx_document()
+        assert result is None
+
+
+class TestIterTextBySuffix:
+    """Test the file-type dispatcher."""
+
+    def test_pdf_dispatch(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import _iter_text_by_suffix
+
+        with patch("docfinder.ingestion.pdf_loader.iter_text_parts") as mock:
+            mock.return_value = iter(["pdf text"])
+            parts = list(_iter_text_by_suffix(tmp_path / "file.pdf"))
+            assert parts == ["pdf text"]
+            mock.assert_called_once()
+
+    def test_txt_dispatch(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import _iter_text_by_suffix
+
+        f = tmp_path / "file.txt"
+        f.write_text("hello")
+        parts = list(_iter_text_by_suffix(f))
+        assert "hello" in parts[0]
+
+    def test_md_dispatch(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import _iter_text_by_suffix
+
+        f = tmp_path / "file.md"
+        f.write_text("content")
+        parts = list(_iter_text_by_suffix(f))
+        assert "content" in parts[0]
+
+    def test_docx_dispatch(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import _iter_text_by_suffix
+
+        try:
+            from docx import Document
+        except ImportError:
+            pytest.skip("python-docx not installed")
+
+        f = tmp_path / "file.docx"
+        doc = Document()
+        doc.add_paragraph("docx content")
+        doc.save(str(f))
+        parts = list(_iter_text_by_suffix(f))
+        assert any("docx content" in p for p in parts)
+
+    def test_unsupported_extension(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import _iter_text_by_suffix
+
+        f = tmp_path / "file.xyz"
+        f.write_text("data")
+        parts = list(_iter_text_by_suffix(f))
+        assert parts == []
+
+
+class TestGetTitle:
+    """Test _get_title helper."""
+
+    @patch("docfinder.ingestion.pdf_loader.get_pdf_metadata")
+    def test_pdf_with_title(self, mock_meta: MagicMock, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import _get_title
+
+        mock_meta.return_value = {"title": "My PDF Title"}
+        result = _get_title(tmp_path / "doc.pdf")
+        assert result == "My PDF Title"
+
+    @patch("docfinder.ingestion.pdf_loader.get_pdf_metadata")
+    def test_pdf_metadata_error(self, mock_meta: MagicMock, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import _get_title
+
+        mock_meta.side_effect = Exception("cannot open")
+        result = _get_title(tmp_path / "broken.pdf")
+        assert result == "broken"
+
+    def test_non_pdf_uses_stem(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import _get_title
+
+        result = _get_title(tmp_path / "report.txt")
+        assert result == "report"
+
+
+class TestIterPagedText:
+    """Test the paged text dispatcher."""
+
+    def test_dispatches_pdf(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import _iter_paged_text
+
+        with patch("docfinder.ingestion.pdf_loader.iter_text_parts_paged") as mock:
+            mock.return_value = iter([(1, "page text")])
+            pages = list(_iter_paged_text(tmp_path / "file.pdf"))
+            assert pages == [(1, "page text")]
+
+    def test_dispatches_md(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import _iter_paged_text
+
+        f = tmp_path / "file.md"
+        f.write_text("# Hello\nWorld")
+        pages = list(_iter_paged_text(f))
+        assert len(pages) >= 1
+
+    def test_dispatches_txt(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import _iter_paged_text
+
+        f = tmp_path / "file.txt"
+        f.write_text("Some content")
+        pages = list(_iter_paged_text(f))
+        assert len(pages) == 1
+
+    def test_dispatches_docx(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import _iter_paged_text
+
+        try:
+            from docx import Document
+        except ImportError:
+            pytest.skip("python-docx not installed")
+
+        f = tmp_path / "file.docx"
+        doc = Document()
+        doc.add_paragraph("Hello")
+        doc.save(str(f))
+        pages = list(_iter_paged_text(f))
+        assert len(pages) >= 1
+
+    def test_unsupported_returns_empty(self, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import _iter_paged_text
+
+        f = tmp_path / "file.xyz"
+        f.write_text("data")
+        pages = list(_iter_paged_text(f))
+        assert pages == []
+
+
+class TestIterTextPartsPaged:
+    """Test iter_text_parts_paged (PDF-specific paged extraction)."""
+
+    @patch("docfinder.ingestion.pdf_loader.fitz")
+    def test_yields_page_numbers(self, mock_fitz: MagicMock, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import iter_text_parts_paged
+
+        mock_page1 = MagicMock()
+        mock_page1.get_text.return_value = "First page"
+        mock_page1.find_tables.return_value = MagicMock(tables=[])
+        mock_page2 = MagicMock()
+        mock_page2.get_text.return_value = "Second page"
+        mock_page2.find_tables.return_value = MagicMock(tables=[])
+
+        mock_doc = MagicMock()
+        mock_doc.__len__ = MagicMock(return_value=2)
+        mock_doc.__getitem__ = MagicMock(side_effect=[mock_page1, mock_page2])
+        mock_fitz.open.return_value = mock_doc
+
+        pages = list(iter_text_parts_paged(tmp_path / "test.pdf"))
+        assert len(pages) == 2
+        assert pages[0][0] == 1
+        assert pages[1][0] == 2
+        assert "First page" in pages[0][1]
+        assert "Second page" in pages[1][1]
+
+    @patch("docfinder.ingestion.pdf_loader.fitz")
+    def test_open_error(self, mock_fitz: MagicMock, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import iter_text_parts_paged
+
+        mock_fitz.open.side_effect = Exception("cannot open")
+        pages = list(iter_text_parts_paged(tmp_path / "bad.pdf"))
+        assert pages == []
+
+    @patch("docfinder.ingestion.pdf_loader.fitz")
+    def test_skips_empty_pages(self, mock_fitz: MagicMock, tmp_path: Path) -> None:
+        from docfinder.ingestion.pdf_loader import iter_text_parts_paged
+
+        mock_page1 = MagicMock()
+        mock_page1.get_text.return_value = "Content"
+        mock_page1.find_tables.return_value = MagicMock(tables=[])
+        mock_page2 = MagicMock()
+        mock_page2.get_text.return_value = ""
+        mock_page2.find_tables.return_value = MagicMock(tables=[])
+
+        mock_doc = MagicMock()
+        mock_doc.__len__ = MagicMock(return_value=2)
+        mock_doc.__getitem__ = MagicMock(side_effect=[mock_page1, mock_page2])
+        mock_fitz.open.return_value = mock_doc
+
+        pages = list(iter_text_parts_paged(tmp_path / "test.pdf"))
+        assert len(pages) == 1

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 
+from docfinder.index.search import SearchResult
 from docfinder.index.storage import SQLiteVectorStore
 from docfinder.models import ChunkRecord, DocumentMetadata
+from docfinder.rag.engine import _SMALL_DOC_THRESHOLD, RAGEngine
 from docfinder.rag.llm import MODEL_TIERS, select_model
 
 # ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -395,3 +398,171 @@ class TestRAGEngineContextAssembly:
         # Chunks should appear in order
         for i in range(4):
             assert text.index(f"chunk_{i}") < text.index(f"chunk_{i + 1}")
+
+
+# ── Hybrid context strategy tests ─────────────────────────────────────────
+
+
+def _make_engine(store: SQLiteVectorStore) -> RAGEngine:
+    """Create a RAGEngine with a mocked searcher and llm."""
+    searcher = MagicMock()
+    llm = MagicMock()
+    return RAGEngine(searcher, store, llm, window_size=10)
+
+
+def _make_result(path: str, chunk_index: int) -> SearchResult:
+    return SearchResult(
+        path=Path(path),
+        title="Doc",
+        chunk_index=chunk_index,
+        score=0.9,
+        text="hit",
+        metadata={},
+    )
+
+
+class TestHybridContextStrategy:
+    """Test that _build_context picks the right strategy based on document size."""
+
+    def test_small_doc_uses_get_all_chunks(self, tmp_path):
+        """Documents with <= SMALL_DOC_THRESHOLD chunks should load entirely."""
+        db_path = tmp_path / "small.db"
+        store = SQLiteVectorStore(db_path, dimension=384)
+
+        n = _SMALL_DOC_THRESHOLD  # exactly at threshold
+        doc = DocumentMetadata(
+            path=Path("/tmp/small.pdf"),
+            title="Small",
+            sha256="small_hash",
+            mtime=1.0,
+            size=1000,
+        )
+        chunks = [
+            ChunkRecord(document_path=doc.path, index=i, text=f"Chunk {i}", metadata={})
+            for i in range(n)
+        ]
+        embeddings = np.random.rand(n, 384).astype("float32")
+        store.upsert_document(doc, chunks, embeddings)
+
+        engine = _make_engine(store)
+        result = _make_result("/tmp/small.pdf", chunk_index=5)
+
+        with (
+            patch.object(store, "get_all_chunks", wraps=store.get_all_chunks) as mock_all,
+            patch.object(
+                store, "get_context_window", wraps=store.get_context_window
+            ) as mock_window,
+        ):
+            ctx = engine._build_context([result])
+
+        mock_all.assert_called_once()
+        mock_window.assert_not_called()
+        # All chunks should be present
+        assert len(ctx) == n
+        store.close()
+
+    def test_large_doc_uses_get_context_window(self, tmp_path):
+        """Documents with > SMALL_DOC_THRESHOLD chunks should use window strategy."""
+        db_path = tmp_path / "large.db"
+        store = SQLiteVectorStore(db_path, dimension=384)
+
+        n = _SMALL_DOC_THRESHOLD + 5  # above threshold
+        doc = DocumentMetadata(
+            path=Path("/tmp/large.pdf"),
+            title="Large",
+            sha256="large_hash",
+            mtime=1.0,
+            size=50000,
+        )
+        chunks = [
+            ChunkRecord(document_path=doc.path, index=i, text=f"Chunk {i}", metadata={})
+            for i in range(n)
+        ]
+        embeddings = np.random.rand(n, 384).astype("float32")
+        store.upsert_document(doc, chunks, embeddings)
+
+        engine = _make_engine(store)
+        result = _make_result("/tmp/large.pdf", chunk_index=12)
+
+        with (
+            patch.object(store, "get_all_chunks", wraps=store.get_all_chunks) as mock_all,
+            patch.object(
+                store, "get_context_window", wraps=store.get_context_window
+            ) as mock_window,
+        ):
+            ctx = engine._build_context([result])
+
+        mock_all.assert_not_called()
+        mock_window.assert_called_once()
+        # Window around chunk 12 with window_size=10 -> indices 2..22
+        assert len(ctx) < n
+        store.close()
+
+    def test_mixed_small_and_large(self, tmp_path):
+        """Query hitting one small doc and one large doc uses both strategies."""
+        db_path = tmp_path / "mixed.db"
+        store = SQLiteVectorStore(db_path, dimension=384)
+
+        # Small document: 5 chunks
+        small_doc = DocumentMetadata(
+            path=Path("/tmp/small.pdf"),
+            title="Small",
+            sha256="s_hash",
+            mtime=1.0,
+            size=500,
+        )
+        small_n = 5
+        small_chunks = [
+            ChunkRecord(document_path=small_doc.path, index=i, text=f"S{i}", metadata={})
+            for i in range(small_n)
+        ]
+        small_emb = np.random.rand(small_n, 384).astype("float32")
+        store.upsert_document(small_doc, small_chunks, small_emb)
+
+        # Large document: 30 chunks
+        large_doc = DocumentMetadata(
+            path=Path("/tmp/large.pdf"),
+            title="Large",
+            sha256="l_hash",
+            mtime=1.0,
+            size=50000,
+        )
+        large_n = 30
+        large_chunks = [
+            ChunkRecord(document_path=large_doc.path, index=i, text=f"L{i}", metadata={})
+            for i in range(large_n)
+        ]
+        large_emb = np.random.rand(large_n, 384).astype("float32")
+        store.upsert_document(large_doc, large_chunks, large_emb)
+
+        engine = _make_engine(store)
+        results = [
+            _make_result("/tmp/small.pdf", chunk_index=2),
+            _make_result("/tmp/large.pdf", chunk_index=15),
+        ]
+
+        with (
+            patch.object(store, "get_all_chunks", wraps=store.get_all_chunks) as mock_all,
+            patch.object(
+                store, "get_context_window", wraps=store.get_context_window
+            ) as mock_window,
+        ):
+            ctx = engine._build_context(results)
+
+        # get_all_chunks called for the small doc
+        mock_all.assert_called_once()
+        # get_context_window called for the large doc
+        mock_window.assert_called_once()
+
+        # Context should contain all small doc chunks + window from large doc
+        paths = {c["path"] for c in ctx}
+        assert "/tmp/small.pdf" in paths
+        assert "/tmp/large.pdf" in paths
+
+        small_ctx = [c for c in ctx if c["path"] == "/tmp/small.pdf"]
+        assert len(small_ctx) == small_n
+
+        large_ctx = [c for c in ctx if c["path"] == "/tmp/large.pdf"]
+        assert len(large_ctx) < large_n
+
+        store.close()

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -14,6 +14,11 @@ from docfinder.models import ChunkRecord, DocumentMetadata
 from docfinder.rag.engine import _SMALL_DOC_THRESHOLD, RAGEngine
 from docfinder.rag.llm import MODEL_TIERS, select_model
 
+
+def _normalize_path(value: str) -> str:
+    return value.replace("\\", "/")
+
+
 # ── Fixtures ─────────────────────────────────────────────────────────────────
 
 
@@ -555,14 +560,14 @@ class TestHybridContextStrategy:
         mock_window.assert_called_once()
 
         # Context should contain all small doc chunks + window from large doc
-        paths = {c["path"] for c in ctx}
+        paths = {_normalize_path(c["path"]) for c in ctx}
         assert "/tmp/small.pdf" in paths
         assert "/tmp/large.pdf" in paths
 
-        small_ctx = [c for c in ctx if c["path"] == "/tmp/small.pdf"]
+        small_ctx = [c for c in ctx if _normalize_path(c["path"]) == "/tmp/small.pdf"]
         assert len(small_ctx) == small_n
 
-        large_ctx = [c for c in ctx if c["path"] == "/tmp/large.pdf"]
+        large_ctx = [c for c in ctx if _normalize_path(c["path"]) == "/tmp/large.pdf"]
         assert len(large_ctx) < large_n
 
         store.close()

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -1,0 +1,140 @@
+"""Tests for cross-encoder reranker."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from docfinder.index.reranker import Reranker, _sigmoid
+
+
+class TestReranker:
+    """Test Reranker class."""
+
+    def test_lazy_model_loading(self) -> None:
+        """Model should not be loaded until rerank() is called."""
+        reranker = Reranker()
+        assert reranker._model is None
+
+    @patch("docfinder.index.reranker.CrossEncoder", create=True)
+    def test_model_loaded_on_first_rerank(self, mock_ce_cls: MagicMock) -> None:
+        """Model should be loaded on first rerank() call."""
+        mock_model = MagicMock()
+        mock_model.predict.return_value = np.array([0.9])
+        mock_ce_cls.return_value = mock_model
+
+        reranker = Reranker()
+        with patch("sentence_transformers.CrossEncoder", mock_ce_cls):
+            reranker.rerank("query", [{"text": "doc", "score": 0.5}])
+
+        assert reranker._model is mock_model
+
+    def test_rerank_empty_results(self) -> None:
+        """Should return empty list for empty input without loading model."""
+        reranker = Reranker()
+        result = reranker.rerank("query", [])
+        assert result == []
+        assert reranker._model is None
+
+    def test_rerank_preserves_embedding_score(self) -> None:
+        """Original score should be preserved as embedding_score."""
+        reranker = Reranker()
+        mock_model = MagicMock()
+        mock_model.predict.return_value = np.array([0.8, 0.6])
+        reranker._model = mock_model
+
+        results = [
+            {"text": "doc1", "score": 0.95},
+            {"text": "doc2", "score": 0.90},
+        ]
+        reranked = reranker.rerank("query", results)
+
+        assert reranked[0]["embedding_score"] == 0.95
+        assert reranked[1]["embedding_score"] == 0.90
+
+    def test_rerank_sorts_by_rerank_score(self) -> None:
+        """Results should be sorted by rerank_score descending."""
+        reranker = Reranker()
+        mock_model = MagicMock()
+        # Second result gets higher rerank score
+        mock_model.predict.return_value = np.array([0.3, 0.9, 0.6])
+        reranker._model = mock_model
+
+        results = [
+            {"text": "doc1", "score": 0.95},
+            {"text": "doc2", "score": 0.85},
+            {"text": "doc3", "score": 0.75},
+        ]
+        reranked = reranker.rerank("query", results)
+
+        assert reranked[0]["rerank_score"] == 0.9
+        assert reranked[1]["rerank_score"] == 0.6
+        assert reranked[2]["rerank_score"] == 0.3
+
+    def test_rerank_score_becomes_final_score(self) -> None:
+        """The final 'score' key should be sigmoid(rerank_score)."""
+        reranker = Reranker()
+        mock_model = MagicMock()
+        mock_model.predict.return_value = np.array([0.42])
+        reranker._model = mock_model
+
+        results = [{"text": "doc", "score": 0.99}]
+        reranked = reranker.rerank("query", results)
+
+        assert reranked[0]["score"] == _sigmoid(0.42)
+        assert reranked[0]["rerank_score"] == 0.42
+        assert reranked[0]["embedding_score"] == 0.99
+
+    def test_rerank_top_k_trimming(self) -> None:
+        """Should return at most top_k results."""
+        reranker = Reranker()
+        mock_model = MagicMock()
+        mock_model.predict.return_value = np.array([0.9, 0.8, 0.7, 0.6, 0.5])
+        reranker._model = mock_model
+
+        results = [{"text": f"doc{i}", "score": 0.5} for i in range(5)]
+        reranked = reranker.rerank("query", results, top_k=2)
+
+        assert len(reranked) == 2
+        assert reranked[0]["rerank_score"] == 0.9
+        assert reranked[1]["rerank_score"] == 0.8
+
+    def test_rerank_passes_correct_pairs(self) -> None:
+        """Should pass (query, text) pairs to the cross-encoder."""
+        reranker = Reranker()
+        mock_model = MagicMock()
+        mock_model.predict.return_value = np.array([0.5, 0.6])
+        reranker._model = mock_model
+
+        results = [
+            {"text": "first document", "score": 0.9},
+            {"text": "second document", "score": 0.8},
+        ]
+        reranker.rerank("my query", results)
+
+        pairs = mock_model.predict.call_args[0][0]
+        assert pairs == [("my query", "first document"), ("my query", "second document")]
+
+    def test_default_model_name(self) -> None:
+        """Should use the default model name."""
+        reranker = Reranker()
+        assert reranker.model_name == "cross-encoder/ms-marco-MiniLM-L-2-v2"
+
+    def test_custom_model_name(self) -> None:
+        """Should accept a custom model name."""
+        reranker = Reranker(model_name="custom/model")
+        assert reranker.model_name == "custom/model"
+
+    def test_rerank_preserves_extra_keys(self) -> None:
+        """Should preserve extra keys in result dicts."""
+        reranker = Reranker()
+        mock_model = MagicMock()
+        mock_model.predict.return_value = np.array([0.7])
+        reranker._model = mock_model
+
+        results = [{"text": "doc", "score": 0.5, "path": "/test.pdf", "chunk_index": 3}]
+        reranked = reranker.rerank("query", results)
+
+        assert reranked[0]["path"] == "/test.pdf"
+        assert reranked[0]["chunk_index"] == 3

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -162,6 +162,21 @@ class TestSearcher:
         call_args = mock_store.search.call_args
         assert call_args[1]["top_k"] == 25
 
+    def test_search_passes_folder_filters(self) -> None:
+        """Should pass selected folders down to storage search."""
+        mock_embedder = MagicMock()
+        mock_embedder.embed_query.return_value = np.array([0.1])
+
+        mock_store = MagicMock()
+        mock_store.search.return_value = []
+
+        searcher = Searcher(mock_embedder, mock_store)
+        folders = ["/Users/test/articles", "/Users/test/posters"]
+        searcher.search("query", top_k=10, folders=folders)
+
+        call_args = mock_store.search.call_args
+        assert call_args[1]["folders"] == folders
+
     def test_search_metadata_parsing(self) -> None:
         """Should parse JSON metadata correctly."""
         mock_embedder = MagicMock()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 import numpy as np
 
+from docfinder.index.reranker import Reranker
 from docfinder.index.search import Searcher, SearchResult
 
 
@@ -184,3 +185,93 @@ class TestSearcher:
         results = searcher.search("query")
 
         assert results[0].metadata == complex_metadata
+
+    def test_search_without_reranker(self) -> None:
+        """Should work identically when reranker is None."""
+        mock_embedder = MagicMock()
+        mock_embedder.embed_query.return_value = np.array([0.1, 0.2])
+
+        mock_store = MagicMock()
+        mock_store.search.return_value = [
+            {
+                "path": "/doc.pdf",
+                "title": "Doc",
+                "chunk_index": 0,
+                "score": 0.9,
+                "text": "Text",
+                "metadata": "{}",
+            }
+        ]
+
+        searcher = Searcher(mock_embedder, mock_store, reranker=None)
+        results = searcher.search("query", top_k=5)
+
+        assert len(results) == 1
+        assert results[0].score == 0.9
+        # Without reranker, top_k is passed directly to store
+        call_args = mock_store.search.call_args
+        assert call_args[1]["top_k"] == 5
+
+    def test_search_with_reranker_fetches_more_candidates(self) -> None:
+        """With reranker, should fetch more candidates from the store."""
+        mock_embedder = MagicMock()
+        mock_embedder.embed_query.return_value = np.array([0.1])
+
+        mock_store = MagicMock()
+        mock_store.search.return_value = [
+            {
+                "path": f"/doc{i}.pdf",
+                "title": f"Doc {i}",
+                "chunk_index": 0,
+                "score": 0.9 - i * 0.01,
+                "text": f"Text {i}",
+                "metadata": "{}",
+            }
+            for i in range(30)
+        ]
+
+        mock_reranker = MagicMock(spec=Reranker)
+        mock_reranker.rerank.return_value = [
+            {
+                "path": "/doc5.pdf",
+                "title": "Doc 5",
+                "chunk_index": 0,
+                "score": 0.99,
+                "text": "Text 5",
+                "metadata": "{}",
+            }
+        ]
+
+        searcher = Searcher(mock_embedder, mock_store, reranker=mock_reranker)
+        results = searcher.search("query", top_k=5)
+
+        # Should fetch max(5*3, 30) = 30 candidates
+        call_args = mock_store.search.call_args
+        assert call_args[1]["top_k"] == 30
+
+        # Should have called reranker with the candidates
+        mock_reranker.rerank.assert_called_once()
+        rerank_args = mock_reranker.rerank.call_args
+        assert rerank_args[1]["top_k"] == 5
+
+        # Should return the reranked result
+        assert len(results) == 1
+        assert results[0].path == Path("/doc5.pdf")
+        assert results[0].score == 0.99
+
+    def test_search_with_reranker_empty_results(self) -> None:
+        """With reranker, should handle empty store results gracefully."""
+        mock_embedder = MagicMock()
+        mock_embedder.embed_query.return_value = np.array([0.1])
+
+        mock_store = MagicMock()
+        mock_store.search.return_value = []
+
+        mock_reranker = MagicMock(spec=Reranker)
+
+        searcher = Searcher(mock_embedder, mock_store, reranker=mock_reranker)
+        results = searcher.search("query", top_k=5)
+
+        assert len(results) == 0
+        # Reranker should not be called for empty results
+        mock_reranker.rerank.assert_not_called()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -358,6 +358,84 @@ class TestSearch:
         scores = [r["score"] for r in results]
         assert scores == sorted(scores, reverse=True)
 
+    def test_search_with_folder_filters(self, temp_db):
+        """Search should return only results from selected folders."""
+        doc_a = DocumentMetadata(
+            path=Path("/tmp/folder_a/doc1.pdf"),
+            title="A1",
+            sha256="hash_a1",
+            mtime=1234567890.0,
+            size=1000,
+        )
+        doc_b = DocumentMetadata(
+            path=Path("/tmp/folder_b/doc2.pdf"),
+            title="B1",
+            sha256="hash_b1",
+            mtime=1234567890.0,
+            size=1000,
+        )
+        chunk_a = [ChunkRecord(document_path=doc_a.path, index=0, text="Text A", metadata={})]
+        chunk_b = [ChunkRecord(document_path=doc_b.path, index=0, text="Text B", metadata={})]
+        emb_a = np.random.rand(1, 384).astype("float32")
+        emb_b = np.random.rand(1, 384).astype("float32")
+        temp_db.upsert_document(doc_a, chunk_a, emb_a)
+        temp_db.upsert_document(doc_b, chunk_b, emb_b)
+
+        query = np.random.rand(384).astype("float32")
+        results = temp_db.search(query, top_k=10, folders=["/tmp/folder_a"])
+
+        assert len(results) == 1
+        assert results[0]["path"] == "/tmp/folder_a/doc1.pdf"
+
+
+class TestIndexedDirectories:
+    """Test indexed directory listing for search filters."""
+
+    def test_list_indexed_directories(self, temp_db):
+        doc1 = DocumentMetadata(
+            path=Path("/tmp/alpha/doc1.pdf"),
+            title="Doc 1",
+            sha256="h1",
+            mtime=1234567890.0,
+            size=1000,
+        )
+        doc2 = DocumentMetadata(
+            path=Path("/tmp/alpha/doc2.pdf"),
+            title="Doc 2",
+            sha256="h2",
+            mtime=1234567890.0,
+            size=1000,
+        )
+        doc3 = DocumentMetadata(
+            path=Path("/tmp/beta/doc3.pdf"),
+            title="Doc 3",
+            sha256="h3",
+            mtime=1234567890.0,
+            size=1000,
+        )
+        emb = np.random.rand(1, 384).astype("float32")
+        temp_db.upsert_document(
+            doc1,
+            [ChunkRecord(document_path=doc1.path, index=0, text="a", metadata={})],
+            emb,
+        )
+        temp_db.upsert_document(
+            doc2,
+            [ChunkRecord(document_path=doc2.path, index=0, text="b", metadata={})],
+            emb,
+        )
+        temp_db.upsert_document(
+            doc3,
+            [ChunkRecord(document_path=doc3.path, index=0, text="c", metadata={})],
+            emb,
+        )
+
+        directories = temp_db.list_indexed_directories()
+        assert directories == [
+            {"path": "/tmp/alpha", "document_count": 2},
+            {"path": "/tmp/beta", "document_count": 1},
+        ]
+
 
 class TestRemoveMissingFiles:
     """Test removing documents with missing files."""

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -576,6 +576,106 @@ class TestDeleteDocument:
         assert cursor.fetchone()[0] == 0
 
 
+class TestGetDocumentChunkCount:
+    """Test get_document_chunk_count method."""
+
+    def test_zero_chunks(self, temp_db):
+        """Document with no chunks returns 0."""
+        # Insert a document directly (no chunks)
+        temp_db.connection.execute(
+            "INSERT INTO documents(path, title, sha256, mtime, size) VALUES (?, ?, ?, ?, ?)",
+            ("/tmp/empty.pdf", "Empty", "hash_empty", 1234567890.0, 100),
+        )
+        temp_db.connection.commit()
+        doc_id = temp_db.connection.execute(
+            "SELECT id FROM documents WHERE path = ?", ("/tmp/empty.pdf",)
+        ).fetchone()["id"]
+
+        assert temp_db.get_document_chunk_count(doc_id) == 0
+
+    def test_with_chunks(self, temp_db):
+        """Document with N chunks returns N."""
+        doc = DocumentMetadata(
+            path=Path("/tmp/counted.pdf"),
+            title="Counted",
+            sha256="hash_counted",
+            mtime=1234567890.0,
+            size=1000,
+        )
+        n = 7
+        chunks = [
+            ChunkRecord(document_path=doc.path, index=i, text=f"Chunk {i}", metadata={})
+            for i in range(n)
+        ]
+        embeddings = np.random.rand(n, 384).astype("float32")
+        temp_db.upsert_document(doc, chunks, embeddings)
+
+        doc_id = temp_db.connection.execute(
+            "SELECT id FROM documents WHERE path = ?", (str(doc.path),)
+        ).fetchone()["id"]
+
+        assert temp_db.get_document_chunk_count(doc_id) == n
+
+    def test_nonexistent_document(self, temp_db):
+        """Nonexistent document_id returns 0."""
+        assert temp_db.get_document_chunk_count(9999) == 0
+
+
+class TestGetAllChunks:
+    """Test get_all_chunks method."""
+
+    def test_empty_document(self, temp_db):
+        """Document with no chunks returns empty list."""
+        temp_db.connection.execute(
+            "INSERT INTO documents(path, title, sha256, mtime, size) VALUES (?, ?, ?, ?, ?)",
+            ("/tmp/empty.pdf", "Empty", "hash_empty", 1234567890.0, 100),
+        )
+        temp_db.connection.commit()
+        doc_id = temp_db.connection.execute(
+            "SELECT id FROM documents WHERE path = ?", ("/tmp/empty.pdf",)
+        ).fetchone()["id"]
+
+        assert temp_db.get_all_chunks(doc_id) == []
+
+    def test_returns_all_chunks_ordered(self, temp_db):
+        """All chunks returned in ascending chunk_index order."""
+        doc = DocumentMetadata(
+            path=Path("/tmp/ordered.pdf"),
+            title="Ordered",
+            sha256="hash_ordered",
+            mtime=1234567890.0,
+            size=1000,
+        )
+        n = 5
+        chunks = [
+            ChunkRecord(
+                document_path=doc.path,
+                index=i,
+                text=f"Chunk {i}",
+                metadata={"page": i + 1},
+            )
+            for i in range(n)
+        ]
+        embeddings = np.random.rand(n, 384).astype("float32")
+        temp_db.upsert_document(doc, chunks, embeddings)
+
+        doc_id = temp_db.connection.execute(
+            "SELECT id FROM documents WHERE path = ?", (str(doc.path),)
+        ).fetchone()["id"]
+
+        result = temp_db.get_all_chunks(doc_id)
+
+        assert len(result) == n
+        indices = [c["chunk_index"] for c in result]
+        assert indices == list(range(n))
+        assert "Chunk 0" in result[0]["text"]
+        assert "Chunk 4" in result[4]["text"]
+
+    def test_nonexistent_document(self, temp_db):
+        """Nonexistent document_id returns empty list."""
+        assert temp_db.get_all_chunks(9999) == []
+
+
 class TestGetStats:
     """Test get_stats method."""
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -11,6 +11,10 @@ from docfinder.index.storage import SQLiteVectorStore
 from docfinder.models import ChunkRecord, DocumentMetadata
 
 
+def _normalize_path(value: str) -> str:
+    return value.replace("\\", "/")
+
+
 @pytest.fixture
 def temp_db(tmp_path):
     """Create a temporary database for testing."""
@@ -385,7 +389,7 @@ class TestSearch:
         results = temp_db.search(query, top_k=10, folders=["/tmp/folder_a"])
 
         assert len(results) == 1
-        assert results[0]["path"] == "/tmp/folder_a/doc1.pdf"
+        assert _normalize_path(results[0]["path"]) == "/tmp/folder_a/doc1.pdf"
 
 
 class TestIndexedDirectories:

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -142,7 +142,83 @@ class TestSearchEndpoint:
         # Test with top_k > 50
         response = client.post("/search", json={"query": "test", "db": str(db_path), "top_k": 100})
         assert response.status_code == 200
-        mock_searcher.search.assert_called_with("test", top_k=50)
+        mock_searcher.search.assert_called_with("test", top_k=50, folders=None)
+
+    @patch("docfinder.web.app.EmbeddingModel")
+    @patch("docfinder.web.app.SQLiteVectorStore")
+    @patch("docfinder.web.app.Searcher")
+    def test_search_passes_folder_filters(
+        self,
+        mock_searcher_class: MagicMock,
+        mock_store_class: MagicMock,
+        mock_embedder_class: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Passes selected folder filters to Searcher."""
+        db_path = tmp_path / "test.db"
+        db_path.touch()
+
+        mock_embedder = MagicMock()
+        mock_embedder.dimension = 768
+        mock_embedder_class.return_value = mock_embedder
+
+        mock_store = MagicMock()
+        mock_store_class.return_value = mock_store
+
+        mock_searcher = MagicMock()
+        mock_searcher.search.return_value = []
+        mock_searcher_class.return_value = mock_searcher
+
+        folders = ["/Users/test/articles", "/Users/test/posters"]
+        response = client.post(
+            "/search",
+            json={"query": "test", "db": str(db_path), "top_k": 10, "folders": folders},
+        )
+        assert response.status_code == 200
+        mock_searcher.search.assert_called_with("test", top_k=10, folders=folders)
+
+
+class TestSearchFoldersEndpoint:
+    """Tests for GET /search/folders endpoint."""
+
+    def test_search_folders_database_not_found(self, tmp_path: Path) -> None:
+        """Returns empty folders list when DB is missing."""
+        db_path = tmp_path / "missing.db"
+        response = client.get(f"/search/folders?db={db_path}")
+        assert response.status_code == 200
+        assert response.json() == {"folders": []}
+
+    @patch("docfinder.web.app.EmbeddingModel")
+    @patch("docfinder.web.app.SQLiteVectorStore")
+    def test_search_folders_success(
+        self,
+        mock_store_class: MagicMock,
+        mock_embedder_class: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Returns indexed folder list with counts."""
+        db_path = tmp_path / "test.db"
+        db_path.touch()
+
+        mock_embedder = MagicMock()
+        mock_embedder.dimension = 768
+        mock_embedder_class.return_value = mock_embedder
+
+        mock_store = MagicMock()
+        mock_store.list_indexed_directories.return_value = [
+            {"path": "/Users/test/articles", "document_count": 7},
+            {"path": "/Users/test/posters", "document_count": 2},
+        ]
+        mock_store_class.return_value = mock_store
+
+        response = client.get(f"/search/folders?db={db_path}")
+        assert response.status_code == 200
+        assert response.json() == {
+            "folders": [
+                {"path": "/Users/test/articles", "document_count": 7},
+                {"path": "/Users/test/posters", "document_count": 2},
+            ]
+        }
 
 
 class TestOpenEndpoint:

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -36,6 +36,21 @@ class TestHelperFunctions:
         assert db_path.parent.exists()
 
 
+class TestSystemInfoEndpoint:
+    """Tests for GET /system/info endpoint."""
+
+    def test_system_info_contains_runtime_fields(self) -> None:
+        """Returns memory + runtime backend/indexing details."""
+        response = client.get("/system/info")
+        assert response.status_code == 200
+        data = response.json()
+        assert "available_mb" in data
+        assert "total_mb" in data
+        assert "selected_backend" in data
+        assert "selected_device" in data
+        assert "indexing_mode" in data
+
+
 class TestSearchEndpoint:
     """Tests for POST /search endpoint."""
 


### PR DESCRIPTION
## Description
This PR prepares the `2.1.0` release with three main improvements: (1) more robust runtime fallback so embedding does not fall back to CPU when a better torch device is available, (2) new folder-based filtering in the Search UI/API to query only selected indexed directories, and (3) Spotlight UI/UX fixes (rounded search input and less aggressive filtering so results are not silently hidden).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Code style update (formatting, renaming)
- [ ] ♻️ Code refactor (no functional changes)
- [x] ⚡ Performance improvement
- [x] ✅ Test update
- [ ] 🔧 Configuration change
- [ ] 🏗️ Build/CI update

## Related Issues
<!-- Link related issues below. Use "Fixes #123" to auto-close issues when merged -->

Fixes #41 

## Changes Made
<!-- List the key changes made in this PR -->

- Added search-time folder filtering end-to-end:
  - `POST /search` now accepts optional `folders: []`
  - new `GET /search/folders` endpoint to list indexed directories with document counts
  - storage-level filtering by path prefix (no re-index needed)
  - Search tab UI now includes folder filter panel with checkboxes and All/None actions
- Fixed embedding backend fallback behavior:
  - when ONNX loading fails, fallback now selects the best torch device (`cuda`/`mps`/`cpu`) instead of forcing CPU
- Fixed Spotlight panel usability:
  - smoother rounded search input styling
  - reduced minimum query length (3 -> 2)
  - softened score cutoff and added fallback rendering so relevant results are not accidentally hidden
- Added/updated tests in:
  - `tests/test_embedding_backend.py`
  - `tests/test_search.py`
  - `tests/test_storage.py`
  - `tests/test_web_app.py`

## Testing
<!-- Describe the tests you ran and/or added -->

- [x] Existing tests pass locally
- [x] Added new tests for the changes
- [ ] Manual testing performed

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

<img width="708" height="295" alt="Screenshot 2026-04-25 alle 10 33 46" src="https://github.com/user-attachments/assets/870398e9-7305-4d6e-ac63-89880f671ea2" />

<img width="896" height="88" alt="Screenshot 2026-04-25 alle 10 34 11" src="https://github.com/user-attachments/assets/b58a066a-3a4a-4f9b-bd28-a40e9befebe8" />
