### PR TITLE
fix: context window + model loading + LLM error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.3] - 2026-05-13
+
+### Added
+- **Open button in Library** — Each document row in the Library tab now has an "Open" button to open the file with the system default application
+- **Settings panel reorganization** — Settings tab split into three distinct cards for better UX: Shortcuts, AI Chat (RAG), and Configuration
+
+### Fixed
+- **RAG LLM context window overflow** — `_load_rag_llm()` was hardcoded to `n_ctx=4096` instead of using the model spec's `ctx_size` (8192 for all Qwen2.5 models), causing "Requested tokens exceed context window" errors. The context budget in `rag_chat()` is now dynamically calculated from `_rag_llm.n_ctx - 800`
+- **RAG model not loading on startup** — `loadRagEnabled()` now auto-triggers model load on page load instead of only when the Settings tab is opened, fixing "RAG model not loaded" errors when chatting immediately after search
+- **Safari/WebKit JSON parsing crash** — `sendChat()` now uses `res.text()` + manual `JSON.parse()` with fallback instead of `res.json()`, preventing Safari's cryptic "The string did not match the expected pattern" DOM Exception 12 when the server returns non-JSON responses
+- **RAG LLM error handling** — Added `try/except` around `_rag_llm.chat()` to return a proper JSON 502 error instead of an unhandled exception HTML page
+
+### Changed
+- **LocalLLM** now exposes `n_ctx` as a public attribute for dynamic context sizing
+
 ## [2.1.2] - 2026-05-11
 
 ### Fixed
@@ -265,7 +280,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed linting issues for consistent code style
 - Updated ruff configuration to use non-deprecated settings
 
-[Unreleased]: https://github.com/filippostanghellini/DocFinder/compare/v2.1.2...HEAD
+[Unreleased]: https://github.com/filippostanghellini/DocFinder/compare/v2.1.3...HEAD
+[2.1.3]: https://github.com/filippostanghellini/DocFinder/compare/v2.1.2...v2.1.3
 [2.1.2]: https://github.com/filippostanghellini/DocFinder/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/filippostanghellini/DocFinder/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/filippostanghellini/DocFinder/compare/v2.0.0...v2.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docfinder"
-version = "2.1.2"
+version = "2.1.3"
 license = "AGPL-3.0-or-later"
 description = "Local-first semantic search CLI for your documents (PDF, DOCX, Markdown, TXT)."
 authors = [

--- a/src/docfinder/__init__.py
+++ b/src/docfinder/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "2.1.1"
+__version__ = "2.1.3"

--- a/src/docfinder/rag/llm.py
+++ b/src/docfinder/rag/llm.py
@@ -177,6 +177,7 @@ class LocalLLM:
             n_ctx,
             n_gpu_layers,
         )
+        self.n_ctx = n_ctx
         self._llm = Llama(
             model_path=str(model_path),
             n_ctx=n_ctx,

--- a/src/docfinder/web/app.py
+++ b/src/docfinder/web/app.py
@@ -115,7 +115,7 @@ async def lifespan(app: FastAPI):
     yield
 
 
-app = FastAPI(title="DocFinder Web", version="2.1.1", lifespan=lifespan)
+app = FastAPI(title="DocFinder Web", version="2.1.3", lifespan=lifespan)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -283,7 +283,7 @@ def _load_rag_llm(model_name: str | None = None) -> None:
             HfTqdm.update = _orig_update
 
     _rag_download["status"] = "loading"
-    _rag_llm = LocalLLM(local_path, n_ctx=4096)
+    _rag_llm = LocalLLM(local_path, n_ctx=spec.ctx_size)
     _rag_download["status"] = "ready"
 
 
@@ -390,7 +390,8 @@ async def rag_chat(payload: RAGPayload) -> dict:
         # Get context: try page-based first, fall back to fixed window
         import json as _json
 
-        max_chars = 4000 * 4  # ~4000 tokens
+        max_tokens_for_context = _rag_llm.n_ctx - 800  # reserve ~800 tokens for prompt overhead
+        max_chars = max(max_tokens_for_context * 4, 1000)  # ~4 chars per token
 
         # Find the page of the clicked chunk
         chunk_row = store.connection.execute(
@@ -440,7 +441,16 @@ async def rag_chat(payload: RAGPayload) -> dict:
                 "content": f"Context:\n{context_text}\n\nQuestion: {question}",
             },
         ]
-        answer = await asyncio.to_thread(_rag_llm.chat, messages, max_tokens=1024, temperature=0.2)
+        try:
+            answer = await asyncio.to_thread(
+                _rag_llm.chat, messages, max_tokens=1024, temperature=0.2
+            )
+        except Exception as exc:
+            LOGGER.exception("RAG LLM chat failed")
+            raise HTTPException(
+                status_code=502,
+                detail=f"RAG model failed to generate a response: {exc}",
+            )
     finally:
         store.close()
 

--- a/src/docfinder/web/templates/index.html
+++ b/src/docfinder/web/templates/index.html
@@ -1480,11 +1480,9 @@
           </h2>
           <ul class="tips-list">
             <li>Use absolute paths — e.g. <code>/Users/name/Documents</code></li>
-            <li>Index entire folders: all PDFs are discovered recursively</li>
+            <li>Index entire folders: all Documents are discovered recursively</li>
             <li>Use the <strong>Browse</strong> button to open a native folder picker</li>
-            <li>Or drag &amp; drop a folder from Finder / Explorer onto the input field</li>
-            <li>Already-indexed documents are automatically updated if modified</li>
-            <li>Unchanged files are skipped — re-indexing is fast</li>
+            <li>Unchanged files are skipped</li>
           </ul>
         </div>
       </div>
@@ -1528,17 +1526,16 @@
 
       <!-- ── Settings ─────────────────────────────────────────────────────── -->
       <div id="settings-section" class="section" role="tabpanel">
+
+        <!-- ── Shortcuts ────────────────────────────────────────────────── -->
         <div class="card">
           <div class="card-header">
             <h2 class="card-title">
-              <svg width="15" height="15" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="2.5" stroke="currentColor" stroke-width="1.4"/><path d="M8 1v2M8 13v2M1 8h2M13 8h2M3.05 3.05l1.41 1.41M11.54 11.54l1.41 1.41M3.05 12.95l1.41-1.41M11.54 4.46l1.41-1.41" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg>
-              Settings
+              <svg width="15" height="15" viewBox="0 0 16 16" fill="none"><rect x="1" y="1" width="14" height="14" rx="2" stroke="currentColor" stroke-width="1.4"/><path d="M5 6l3 3 3-3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              Shortcuts
             </h2>
           </div>
 
-          <h3 style="font-size:0.75rem; font-weight:600; color:var(--text-3); text-transform:uppercase; letter-spacing:0.06em; margin-bottom:0.4rem;">
-            Global Search Shortcut
-          </h3>
           <p style="font-size:0.82rem; color:var(--text-2); margin-bottom:0.65rem; line-height:1.5;">
             Press this shortcut from anywhere on your desktop to bring DocFinder to the front and jump directly to search.
           </p>
@@ -1572,58 +1569,68 @@
           <div style="margin-top:1rem; display:flex; justify-content:flex-end;">
             <button id="save-settings-btn" class="btn btn-primary">Save settings</button>
           </div>
+        </div>
 
-          <!-- ── AI Chat (RAG) ──────────────────────────────────────────── -->
-          <div style="margin-top:1.5rem; padding-top:1rem; border-top:1px solid var(--border);">
-            <h3 style="font-size:0.75rem; font-weight:600; color:var(--text-3); text-transform:uppercase; letter-spacing:0.06em; margin-bottom:0.4rem;">
+        <!-- ── AI Chat (RAG) ────────────────────────────────────────────── -->
+        <div class="card">
+          <div class="card-header">
+            <h2 class="card-title">
+              <svg width="15" height="15" viewBox="0 0 16 16" fill="none"><path d="M2 3h12v8H5l-3 3V3z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/><path d="M5 6h6M5 8.5h4" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg>
               AI Chat (RAG)
-            </h3>
-            <p style="font-size:0.82rem; color:var(--text-2); margin-bottom:0.65rem; line-height:1.5;">
-              Enable a local AI assistant that can answer questions about your documents.
-              A language model will be downloaded once and runs entirely on your machine &mdash; no data leaves your computer.
-            </p>
-
-            <div class="setting-row">
-              <div class="setting-info">
-                <span class="setting-label">Enable AI Chat</span>
-                <span class="setting-sub">Adds a Chat button on search results</span>
-              </div>
-              <label class="toggle" title="Enable or disable AI Chat">
-                <input type="checkbox" id="rag-enabled" />
-                <span class="toggle-slider"></span>
-              </label>
-            </div>
-
-            <div id="rag-models-section" style="display:none; margin-top:0.75rem;">
-              <p style="font-size:0.82rem; color:var(--text-2); margin-bottom:0.65rem;">
-                Choose a model based on your available RAM (<span id="rag-ram-label">detecting&hellip;</span>):
-              </p>
-              <div id="rag-models-list" style="display:flex; flex-direction:column; gap:0.5rem;"></div>
-
-              <div id="rag-download-progress" style="display:none; margin-top:0.75rem;">
-                <div style="display:flex; justify-content:space-between; font-size:0.78rem; color:var(--text-2); margin-bottom:0.3rem;">
-                  <span id="rag-dl-label">Downloading model&hellip;</span>
-                  <span id="rag-dl-pct">0%</span>
-                </div>
-                <div style="background:var(--bg-3); border-radius:9999px; height:6px; overflow:hidden;">
-                  <div id="rag-dl-bar" style="background:var(--primary); height:100%; width:0%; transition:width 0.3s;"></div>
-                </div>
-                <p id="rag-dl-detail" style="font-size:0.72rem; color:var(--text-3); margin-top:0.25rem;"></p>
-              </div>
-
-              <div id="rag-status-msg" style="display:none; margin-top:0.5rem; font-size:0.82rem; padding:0.5rem 0.7rem; border-radius:var(--radius-sm);"></div>
-            </div>
+            </h2>
           </div>
 
-          <div style="margin-top:1.5rem; padding-top:1rem; border-top:1px solid var(--border);">
-            <h3 style="font-size:0.75rem; font-weight:600; color:var(--text-3); text-transform:uppercase; letter-spacing:0.06em; margin-bottom:0.4rem;">
-              Configuration settings
-            </h3>
-            <div class="info-box" id="runtime-info-box" style="margin-top:0.6rem;">
-              Runtime acceleration: detecting...
+          <p style="font-size:0.82rem; color:var(--text-2); margin-bottom:0.65rem; line-height:1.5;">
+            Enable a local AI assistant that can answer questions about your documents.
+            A language model will be downloaded once and runs entirely on your machine &mdash; no data leaves your computer.
+          </p>
+
+          <div class="setting-row">
+            <div class="setting-info">
+              <span class="setting-label">Enable AI Chat</span>
+              <span class="setting-sub">Adds a Chat button on search results</span>
             </div>
+            <label class="toggle" title="Enable or disable AI Chat">
+              <input type="checkbox" id="rag-enabled" />
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+
+          <div id="rag-models-section" style="display:none; margin-top:0.75rem;">
+            <p style="font-size:0.82rem; color:var(--text-2); margin-bottom:0.65rem;">
+              Choose a model based on your available RAM (<span id="rag-ram-label">detecting&hellip;</span>):
+            </p>
+            <div id="rag-models-list" style="display:flex; flex-direction:column; gap:0.5rem;"></div>
+
+            <div id="rag-download-progress" style="display:none; margin-top:0.75rem;">
+              <div style="display:flex; justify-content:space-between; font-size:0.78rem; color:var(--text-2); margin-bottom:0.3rem;">
+                <span id="rag-dl-label">Downloading model&hellip;</span>
+                <span id="rag-dl-pct">0%</span>
+              </div>
+              <div style="background:var(--bg-3); border-radius:9999px; height:6px; overflow:hidden;">
+                <div id="rag-dl-bar" style="background:var(--primary); height:100%; width:0%; transition:width 0.3s;"></div>
+              </div>
+              <p id="rag-dl-detail" style="font-size:0.72rem; color:var(--text-3); margin-top:0.25rem;"></p>
+            </div>
+
+            <div id="rag-status-msg" style="display:none; margin-top:0.5rem; font-size:0.82rem; padding:0.5rem 0.7rem; border-radius:var(--radius-sm);"></div>
           </div>
         </div>
+
+        <!-- ── Configuration settings ───────────────────────────────────── -->
+        <div class="card">
+          <div class="card-header">
+            <h2 class="card-title">
+              <svg width="15" height="15" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="2.5" stroke="currentColor" stroke-width="1.4"/><path d="M8 1v2M8 13v2M1 8h2M13 8h2M3.05 3.05l1.41 1.41M11.54 11.54l1.41 1.41M3.05 12.95l1.41-1.41M11.54 4.46l1.41-1.41" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg>
+              Configuration
+            </h2>
+          </div>
+
+          <div class="info-box" id="runtime-info-box">
+            Runtime acceleration: detecting...
+          </div>
+        </div>
+
       </div>
     </main>
 
@@ -2232,7 +2239,7 @@
                     <th>Size</th>
                     <th>Chunks</th>
                     <th>Indexed</th>
-                    <th style="width:40px;"></th>
+                    <th style="width:80px;">Actions</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -2244,7 +2251,10 @@
                       <td class="doc-meta">${formatSize(doc.size)}</td>
                       <td class="doc-meta">${doc.chunk_count}</td>
                       <td class="doc-meta">${formatDate(doc.updated_at)}</td>
-                      <td>
+                      <td style="white-space:nowrap;">
+                        <button class="btn btn-ghost btn-sm open-doc-btn" data-path="${escHtml(doc.path)}" title="Open file">
+                          <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M2 4h8l2 2v8H2V4z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/><path d="M10 2h4v4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path d="M9 7l5-5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/></svg>
+                        </button>
                         <button class="btn btn-ghost btn-sm delete-doc-btn" data-id="${doc.id}" data-title="${escHtml(doc.title || doc.path)}" title="Remove from index">
                           <svg width="13" height="13" viewBox="0 0 16 16" fill="none"><path d="M3 4h10M6 4V2h4v2M13 4l-1 10H4L3 4" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
                         </button>
@@ -2264,6 +2274,10 @@
 
           document.querySelectorAll('.delete-doc-btn').forEach(btn => {
             btn.addEventListener('click', () => showDeleteModal([parseInt(btn.dataset.id)], btn.dataset.title));
+          });
+
+          document.querySelectorAll('.open-doc-btn').forEach(btn => {
+            btn.addEventListener('click', () => openDocument(btn.dataset.path));
           });
 
         } catch (err) {
@@ -2489,6 +2503,18 @@
           ragEnabled = s.rag_enabled === true;
           ragEnabledToggle.checked = ragEnabled;
           updateChatButtonsVisibility();
+          if (ragEnabled) {
+            // Auto-trigger model load on startup if model is downloaded but not yet loaded
+            const dlRes = await fetch(`${apiBase}/rag/download/status`);
+            const dlStatus = await dlRes.json();
+            if (dlStatus.status !== 'ready' && dlStatus.status !== 'loading') {
+              fetch(`${apiBase}/rag/download`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({}),
+              });
+            }
+          }
         } catch (_err) {}
       }
 
@@ -2793,13 +2819,18 @@
             }),
           });
           loadingDiv.remove();
+          const bodyText = await res.text();
+          let body;
+          try { body = JSON.parse(bodyText); } catch { body = null; }
           if (!res.ok) {
-            const err = await res.json();
-            addChatMsg('system', err.detail || 'Error generating answer');
+            addChatMsg('system', body?.detail || body?.message || bodyText || 'Error generating answer');
             return;
           }
-          const data = await res.json();
-          addChatMsg('assistant', data.answer);
+          if (!body || !body.answer) {
+            addChatMsg('system', bodyText || 'Empty response from server');
+            return;
+          }
+          addChatMsg('assistant', body.answer);
         } catch (err) {
           loadingDiv.remove();
           addChatMsg('system', 'Connection error: ' + err.message);

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -4,4 +4,4 @@ from docfinder import __version__
 
 
 def test_version_present() -> None:
-    assert __version__ == "2.1.1"
+    assert __version__ == "2.1.3"


### PR DESCRIPTION
## Description

Bug fixes and UX improvements for v2.1.3: fixed RAG context window overflow (hardcoded `n_ctx=4096`), auto-load RAG model on startup, reorganised Settings into 3 panels.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made

- **RAG LLM context window fix** (`src/docfinder/web/app.py:286`) — Changed `n_ctx=4096` (hardcoded) → `n_ctx=spec.ctx_size` (8192 for all Qwen2.5 models)
- **Dynamic context sizing** (`src/docfinder/web/app.py:393-394`) — Context budget now computed from `_rag_llm.n_ctx - 800` instead of fixed 4000 tokens
- **RAG LLM error handling** (`src/docfinder/web/app.py:444-452`) — Added `try/except` around `_rag_llm.chat()` returning JSON 502 instead of HTML crash page
- **Expose n_ctx on LocalLLM** (`src/docfinder/rag/llm.py:180`) — Added `self.n_ctx = n_ctx` public attribute
- **Auto-load RAG model on startup** (`web/templates/index.html:2492-2502`) — `loadRagEnabled()` now triggers model load on page load, not only when opening Settings
- **Safari/WebKit JSON parse fix** (`web/templates/index.html:2796-2807`) — `sendChat()` uses `res.text()` + manual `JSON.parse()` fallback instead of `res.json()`
- **Open button in Library** (`web/templates/index.html:2254-2257, 2279-2281`) — Added Open button (folder icon) to each document row in the Library table
- **Settings panel reorganization** (`web/templates/index.html:1528-1625`) — Split single card into 3 separate cards: Shortcuts, AI Chat (RAG), Configuration


## Testing

- [x] Existing tests pass locally
- [ ] Added new tests for the changes
- [x] Manual testing performed

### Test Coverage
- Coverage before: ~65%
- Coverage after: ~65% (no regression)